### PR TITLE
Make Enter submit definitions again

### DIFF
--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -241,8 +241,7 @@
 					true,
 				)
 			"
-			@keypress.exact.13="create"
-			@keypress.shift.13=""
+			@keypress.enter.exact.prevent="create"
 			:value.sync="new_body"
 			autocomplete="off"
 			autocorrect="on"


### PR DESCRIPTION
This is the old behavior. I vaguely recall this change wasn't intentional; in fact `@keypress.exact.13="create"` certainly looks like it wants Enter to submit definitions, but it doesn't seem to work.

With this PR, you can still press Shift+Enter to add a newline in a definition, but I think usually definitions should be one line.