### PR TITLE
Fix server startup on Windows

### DIFF
--- a/core/server.ts
+++ b/core/server.ts
@@ -2,7 +2,7 @@
 // the server, duh
 
 import { dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 console.log('-----------');
 
@@ -33,7 +33,9 @@ import * as commons from './commons.js';
 let config = commons.config;
 
 const VERSION = (
-	await import(`${installation_dir}/package.json`, { assert: { type: 'json' } })
+	await import(pathToFileURL(`${installation_dir}/package.json`).href, {
+		assert: { type: 'json' },
+	})
 ).default.version;
 
 console.log(`starting up v${VERSION}...`);


### PR DESCRIPTION
Fixes this error:
```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:399:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1059:11)
    at defaultResolve (node:internal/modules/esm/resolve:1135:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/esm/translators:110:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at file:///C:/code/toadua/dist/core/server.js:29:17 {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```
Apparently the argument to `import` should be a `file://` URL if it's absolute.