### PR TITLE
Easier ꝡ

### DIFF
--- a/core/search.ts
+++ b/core/search.ts
@@ -16,7 +16,7 @@ import {
 var cache: CachedEntry[] = [];
 
 const RE_TRAITS = ['id', 'user', 'scope', 'head', 'body', 'date'] as const;
-type Trait = (typeof RE_TRAITS)[number];
+type Trait = typeof RE_TRAITS[number];
 
 type ReCache = Record<Trait, Record<string, (entry: CachedEntry) => boolean>>;
 const empty_re_cache = () =>

--- a/core/search.ts
+++ b/core/search.ts
@@ -16,7 +16,7 @@ import {
 var cache: CachedEntry[] = [];
 
 const RE_TRAITS = ['id', 'user', 'scope', 'head', 'body', 'date'] as const;
-type Trait = typeof RE_TRAITS[number];
+type Trait = (typeof RE_TRAITS)[number];
 
 type ReCache = Record<Trait, Record<string, (entry: CachedEntry) => boolean>>;
 const empty_re_cache = () =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@types/request-promise-native": "^1.0.18",
 				"@types/shortid": "^0.0.29",
 				"@types/uuid": "^9.0.0",
-				"prettier": "^2.8.1",
+				"prettier": "^3.0.3",
 				"typescript": "^4.5.5"
 			},
 			"engines": {
@@ -413,15 +413,15 @@
 			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
 		},
 		"node_modules/prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+			"integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
 			"dev": true,
 			"bin": {
-				"prettier": "bin-prettier.js"
+				"prettier": "bin/prettier.cjs"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=14"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -998,9 +998,9 @@
 			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
 		},
 		"prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+			"integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
 			"dev": true
 		},
 		"psl": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@types/request-promise-native": "^1.0.18",
 		"@types/shortid": "^0.0.29",
 		"@types/uuid": "^9.0.0",
-		"prettier": "^2.8.1",
+		"prettier": "^3.0.3",
 		"typescript": "^4.5.5"
 	},
 	"scripts": {


### PR DESCRIPTION
This is @uakci's simpler approach to ꝡ-matching. Now searching for `yawa` will find `ꝡaꝡa`.
