### PR TITLE
Limit the event queue

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -216,7 +216,7 @@ actions.create = guard(
 	},
 	(ret, i, uname) => {
 		let id = shortid.generate();
-		let this_entry = {
+		let this_entry: Entry = {
 			id,
 			date: new Date().toISOString(),
 			head: shared.normalize(i.head),

--- a/modules/announce.ts
+++ b/modules/announce.ts
@@ -13,7 +13,7 @@ interface WebhookEmbed {
 	color?: number;
 	title?: string;
 	fields?: { name: string; value: string }[];
-	description: string;
+	description?: string;
 	url?: string;
 }
 
@@ -72,7 +72,12 @@ export function message(what: WebhookEmbed) {
 
 function send_off() {
 	if (!queue.length) return;
-	let m = queue.pop();
+	if (queue.length > 10) {
+		queue.splice(0, queue.length);
+		message({ title: `${queue.length} events omitted` });
+		return;
+	}
+	let m = queue.shift();
 	request(m).then(
 		() => {
 			console.log(`-> '${m.body.embeds[0].title}' announced`);


### PR DESCRIPTION
The only real functionality change here is this bit:

```ts
	if (queue.length > 10) {
		queue.splice(0, queue.length);
		message({ title: `${queue.length} events omitted` });
		return;
	}
	let m = queue.shift();
```