### PR TITLE
Deburr hyphens; reward typographically exact matches

### DIFF
--- a/core/commons.ts
+++ b/core/commons.ts
@@ -28,7 +28,7 @@ export function log(...args: any[]): void {
 export function deburr(s: string): string[] {
 	return s
 		.normalize('NFD')
-		.replace(/\p{M}+/gu, '')
+		.replace(/\p{M}+|-/gu, '')
 		.replace(/[ʼ‘’]/g, "'")
 		.split(/(?:(?!['-])\P{L})+/gu)
 		.map(_ => _.toLowerCase().replace(/ı/g, 'i'))


### PR DESCRIPTION
Right now searching `bu-she` does not find `bụshe`. This PR fixes that, by editing a regex in `deburr` to make it discard hyphens entirely.

But now there is no longer a difference between searching `bu` and `bu-`. So, to float the right one to the top for either query, let's award bonus points to entries that match a bare search term exactly (pre-deburring).