### PR TITLE
Remove notes before triggering cache invalidation

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -244,9 +244,10 @@ actions.removenote = guard(
 	(ret, i, uname) => {
 		let word = by_id(i.id);
 		let keep = [];
+		let removed_notes = [];
 		for (const note of word.notes) {
 			if (note.user === uname && note.date === i.date) {
-				emitter.emit('removenote', word, note);
+				removed_notes.push(note);
 			} else {
 				keep.push(note);
 			}
@@ -255,6 +256,9 @@ actions.removenote = guard(
 			return ret(flip('no such note by you'));
 		}
 		word.notes = keep;
+		for (const note of removed_notes) {
+			emitter.emit('removenote', word, note);
+		}
 		ret(good({ entry: present(word, uname) }));
 	},
 );


### PR DESCRIPTION
Should fix the issue reported by taq in #toashuaq [here](https://discord.com/channels/311223912044167168/361588038586990592/1315431040122359859).

Calling `emitter.emit('removenote')` before doing `word.notes = keep` means the removed note is still attached to the word when this code in search.ts recomputes the cache entry:

```ts
for (let k of ['vote', 'note', 'removenote', 'edit', 'move'])
	emitter.on(k, (_, entry) =>
		cache.splice(cached_index(entry.id), 1, cacheify(entry)),
	);
```

and then the removed note is still in the cache when answering a search query.