### PR TITLE
Inline `guard` in api.ts

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -301,22 +301,20 @@ actions.create = guard(
 	},
 );
 
-actions.login = guard(
-	false,
-	{
-		name: checks.present,
-		pass: checks.present,
-	},
-	(ret, i) => {
-		const expected = store.pass.hashes[i.name];
-		if (!expected) return ret(flip('user not registered'));
-		if (bcrypt.compareSync(i.pass, expected)) {
-			const token = uuid.v4();
-			store.pass.tokens[token] = { name: i.name, last: +new Date() };
-			ret(good({ token }));
-		} else ret(flip("password doesn't match"));
-	},
-);
+actions.login = (ret, i) => {
+	const e_name = checks.present(i.name);
+	if (e_name !== true) return ret(flip(`invalid field 'name': ${e_name}`));
+	const e_pass = checks.present(i.pass);
+	if (e_pass !== true) return ret(flip(`invalid field 'pass': ${e_pass}`));
+
+	const expected = store.pass.hashes[i.name];
+	if (!expected) return ret(flip('user not registered'));
+	if (bcrypt.compareSync(i.pass, expected)) {
+		const token = uuid.v4();
+		store.pass.tokens[token] = { name: i.name, last: +new Date() };
+		ret(good({ token }));
+	} else ret(flip("password doesn't match"));
+};
 
 actions.register = (ret: Ret, i: any, uname: string) => {
 	if (!i.name.match(/^[a-zA-Z]{1,64}$/)) {

--- a/core/api.ts
+++ b/core/api.ts
@@ -218,31 +218,31 @@ actions.note = guard(
 	},
 );
 
-actions.edit = guard(
-	true,
-	{
-		id: checks.goodid,
-		body: checks.nobomb,
-		scope: checks.scope,
-	},
-	(ret, i, uname) => {
-		const word = by_id(i.id);
-		if (word.user !== uname) {
-			return ret(flip('you are not the owner of this entry'));
-		}
-		const new_body = replacements(i.body);
-		const body_changed = word.body !== new_body;
-		const scope_changed = word.scope !== i.scope;
-		word.body = new_body;
-		word.scope = i.scope;
-		ret(good({ entry: present(word, uname) }));
-		if (body_changed) {
-			emitter.emit('edit', word);
-		} else if (scope_changed) {
-			emitter.emit('move', word);
-		}
-	},
-);
+actions.edit = (ret, i, uname) => {
+	if (!uname) return ret(flip('must be logged in'));
+	const e_id = checks.goodid(i.id);
+	if (e_id !== true) return ret(flip(`invalid field 'id': ${e_id}`));
+	const e_body = checks.nobomb(i.body);
+	if (e_body !== true) return ret(flip(`invalid field 'body': ${e_body}`));
+	const e_scope = checks.scope(i.scope);
+	if (e_scope !== true) return ret(flip(`invalid field 'scope': ${e_scope}`));
+
+	const word = by_id(i.id);
+	if (word.user !== uname) {
+		return ret(flip('you are not the owner of this entry'));
+	}
+	const new_body = replacements(i.body);
+	const body_changed = word.body !== new_body;
+	const scope_changed = word.scope !== i.scope;
+	word.body = new_body;
+	word.scope = i.scope;
+	ret(good({ entry: present(word, uname) }));
+	if (body_changed) {
+		emitter.emit('edit', word);
+	} else if (scope_changed) {
+		emitter.emit('move', word);
+	}
+};
 
 actions.removenote = (ret, i, uname) => {
 	if (!uname) return ret(flip('must be logged in'));

--- a/core/api.ts
+++ b/core/api.ts
@@ -126,7 +126,9 @@ function present(e: Entry, uname: string | undefined): PresentedEntry {
 	};
 }
 
-actions.welcome = (ret, i, uname) => ret(good({ name: uname }));
+actions.welcome = (ret, i, uname) => {
+	return ret(good({ name: uname }));
+};
 
 actions.search = (ret, i, uname) => {
 	const e_query = checks.present(i.query);
@@ -147,8 +149,8 @@ actions.search = (ret, i, uname) => {
 			flip(`invalid field 'preferred_scope_bias': ${e_preferred_scope_bias}`),
 		);
 	const data = search.search(i, uname);
-	if (typeof data === 'string') ret(flip(data));
-	else ret(good({ results: data }));
+	if (typeof data === 'string') return ret(flip(data));
+	return ret(good({ results: data }));
 };
 
 actions.count = (ret, i, uname) => {
@@ -296,8 +298,9 @@ actions.login = (ret, i) => {
 	if (bcrypt.compareSync(i.pass, expected)) {
 		const token = uuid.v4();
 		store.pass.tokens[token] = { name: i.name, last: +new Date() };
-		ret(good({ token }));
-	} else ret(flip("password doesn't match"));
+		return ret(good({ token }));
+	}
+	return ret(flip("password doesn't match"));
 };
 
 actions.register = (ret: Ret, i: any, uname: string) => {
@@ -305,7 +308,7 @@ actions.register = (ret: Ret, i: any, uname: string) => {
 		return ret(flip(`invalid field 'id': name must be 1-64 Latin characters`));
 	}
 	const e_pass = checks.limit(128)(i.pass);
-	if (e_pass !== true) ret(flip(`invalid field 'pass': ${e_pass}`));
+	if (e_pass !== true) return ret(flip(`invalid field 'pass': ${e_pass}`));
 
 	return ret(flip('registrations are temporarily disabled'));
 	// if (store.pass.hashes[i.name]) return ret(flip('already registered'));

--- a/core/api.ts
+++ b/core/api.ts
@@ -318,29 +318,27 @@ actions.login = guard(
 	},
 );
 
-actions.register = guard(
-	false,
-	{
-		name: it =>
-			(it.match(/^[a-zA-Z]{1,64}$/) && true) ||
-			'name must be 1-64 Latin characters',
-		pass: checks.limit(128),
-	},
-	(ret, i) => {
-		return ret(flip('registrations are temporarily disabled'));
-		// if (store.pass.hashes[i.name]) return ret(flip('already registered'));
-		// store.pass.hashes[i.name] = bcrypt.hashSync(
-		// 	i.pass,
-		// 	config.password_rounds,
-		// );
-		// actions.login(ret, { name: i.name, pass: i.pass });
-	},
-);
+actions.register = (ret: Ret, i: any, uname: string) => {
+	if (!i.name.match(/^[a-zA-Z]{1,64}$/)) {
+		return ret(flip(`invalid field 'id': name must be 1-64 Latin characters`));
+	}
+	const e_pass = checks.limit(128)(i.pass);
+	if (e_pass !== true) ret(flip(`invalid field 'pass': ${e_pass}`));
 
-actions.logout = guard(true, {}, (ret, i, uname) => {
+	return ret(flip('registrations are temporarily disabled'));
+	// if (store.pass.hashes[i.name]) return ret(flip('already registered'));
+	// store.pass.hashes[i.name] = bcrypt.hashSync(
+	// 	i.pass,
+	// 	config.password_rounds,
+	// );
+	// actions.login(ret, { name: i.name, pass: i.pass });
+};
+
+actions.logout = (ret: Ret, i: any, uname: string) => {
+	if (!uname) return ret(flip('must be logged in'));
 	delete store.pass.tokens[i.token];
 	ret(good());
-});
+};
 
 actions.remove = (ret: Ret, i: any, uname: string) => {
 	if (!uname) return ret(flip('must be logged in'));

--- a/core/api.ts
+++ b/core/api.ts
@@ -342,18 +342,15 @@ actions.logout = guard(true, {}, (ret, i, uname) => {
 	ret(good());
 });
 
-actions.remove = guard(
-	true,
-	{
-		id: checks.goodid,
-	},
-	(ret, i, uname) => {
-		const index = index_of(i.id);
-		const entry = store.db.entries[index];
-		if (entry.user !== uname)
-			return ret(flip('you are not the owner of this entry'));
-		store.db.entries.splice(index, 1);
-		ret(good());
-		emitter.emit('remove', entry);
-	},
-);
+actions.remove = (ret: Ret, i: any, uname: string) => {
+	if (!uname) return ret(flip('must be logged in'));
+	const e_id = checks.goodid(i.id);
+	if (e_id !== true) return ret(flip(`invalid field 'id': ${e_id}`));
+	const index = index_of(i.id);
+	const entry = store.db.entries[index];
+	if (entry.user !== uname)
+		return ret(flip('you are not the owner of this entry'));
+	store.db.entries.splice(index, 1);
+	ret(good());
+	emitter.emit('remove', entry);
+};

--- a/core/api.ts
+++ b/core/api.ts
@@ -145,9 +145,7 @@ function present(e: Entry, uname: string | undefined): PresentedEntry {
 	};
 }
 
-actions.welcome = guard(false, {}, (ret, i, uname) =>
-	ret(good({ name: uname })),
-);
+actions.welcome = (ret, i, uname) => ret(good({ name: uname }));
 
 actions.search = guard(
 	false,
@@ -165,9 +163,9 @@ actions.search = guard(
 	},
 );
 
-actions.count = guard(false, {}, (ret, i, uname) => {
+actions.count = (ret, i, uname) => {
 	ret(good({ count: store.db.entries.length }));
-});
+};
 
 actions.vote = (ret, i, uname) => {
 	if (!uname) return ret(flip('must be logged in'));

--- a/core/api.ts
+++ b/core/api.ts
@@ -275,31 +275,31 @@ actions.removenote = guard(
 export const replacements = (s: string): string =>
 	s.replace(/___/g, '▯').replace(/\s+$/g, '').normalize('NFC');
 
-actions.create = guard(
-	true,
-	{
-		head: checks.nobomb,
-		body: checks.nobomb,
-		scope: checks.scope,
-	},
-	(ret, i, uname) => {
-		const id = shortid.generate();
-		const this_entry: Entry = {
-			id,
-			date: new Date().toISOString(),
-			head: shared.normalize(i.head),
-			body: replacements(i.body),
-			user: uname,
-			scope: i.scope,
-			notes: [],
-			votes: {},
-			score: 0,
-		};
-		store.db.entries.push(this_entry);
-		ret(good({ entry: present(this_entry, uname) }));
-		emitter.emit('create', this_entry);
-	},
-);
+actions.create = (ret, i, uname) => {
+	if (!uname) return ret(flip('must be logged in'));
+	const e_head = checks.nobomb(i.head);
+	if (e_head !== true) return ret(flip(`invalid field 'head': ${e_head}`));
+	const e_body = checks.nobomb(i.body);
+	if (e_body !== true) return ret(flip(`invalid field 'body': ${e_body}`));
+	const e_scope = checks.scope(i.scope);
+	if (e_scope !== true) return ret(flip(`invalid field 'scope': ${e_scope}`));
+
+	const id = shortid.generate();
+	const this_entry: Entry = {
+		id,
+		date: new Date().toISOString(),
+		head: shared.normalize(i.head),
+		body: replacements(i.body),
+		user: uname,
+		scope: i.scope,
+		notes: [],
+		votes: {},
+		score: 0,
+	};
+	store.db.entries.push(this_entry);
+	ret(good({ entry: present(this_entry, uname) }));
+	emitter.emit('create', this_entry);
+};
 
 actions.login = (ret, i) => {
 	const e_name = checks.present(i.name);

--- a/core/api.ts
+++ b/core/api.ts
@@ -28,7 +28,7 @@ export type ApiResponse = ApiError | ApiSuccess;
 type Ret = (response: ApiResponse) => any;
 
 type ActionFunction = (ret: Ret, i: any, uname?: string) => void;
-type Action = ActionFunction & { checks: Record<string, Check> };
+type Action = ActionFunction;
 
 // `sudoUname` is used to override the user – a kind of sudo mode
 export function call(i: any, baseRet: Ret, sudoUname?: string) {
@@ -58,7 +58,7 @@ export function call(i: any, baseRet: Ret, sudoUname?: string) {
 	const entries = Object.entries(i)
 		.filter(
 			([k, v]) =>
-				Object.keys({ ...(action.checks || {}), uname: uname }).includes(k) &&
+				// Object.keys({ ...(action.checks || {}), uname: uname }).includes(k) &&
 				k !== 'pass',
 		)
 		.map(([k, v]) => `${k}=${JSON.stringify(v)}`)
@@ -100,7 +100,6 @@ function guard(
 			}
 		f(ret, i, uname);
 	};
-	res.checks = conds;
 	return res;
 }
 

--- a/core/api.ts
+++ b/core/api.ts
@@ -199,24 +199,24 @@ actions.vote = guard(
 	},
 );
 
-actions.note = guard(
-	true,
-	{
-		id: checks.goodid,
-		content: checks.nobomb,
-	},
-	(ret, i, uname) => {
-		const word = by_id(i.id);
-		const this_note = {
-			date: new Date().toISOString(),
-			user: uname,
-			content: replacements(i.content),
-		};
-		word.notes.push(this_note);
-		ret(good({ entry: present(word, uname) }));
-		emitter.emit('note', word, this_note);
-	},
-);
+actions.note = (ret, i, uname) => {
+	if (!uname) return ret(flip('must be logged in'));
+	const e_id = checks.goodid(i.id);
+	if (e_id !== true) return ret(flip(`invalid field 'id': ${e_id}`));
+	const e_content = checks.nobomb(i.content);
+	if (e_content !== true)
+		return ret(flip(`invalid field 'content': ${e_content}`));
+
+	const word = by_id(i.id);
+	const this_note = {
+		date: new Date().toISOString(),
+		user: uname,
+		content: replacements(i.content),
+	};
+	word.notes.push(this_note);
+	ret(good({ entry: present(word, uname) }));
+	emitter.emit('note', word, this_note);
+};
 
 actions.edit = (ret, i, uname) => {
 	if (!uname) return ret(flip('must be logged in'));

--- a/core/api.ts
+++ b/core/api.ts
@@ -244,33 +244,32 @@ actions.edit = guard(
 	},
 );
 
-actions.removenote = guard(
-	true,
-	{
-		id: checks.goodid,
-		date: checks.present,
-	},
-	(ret, i, uname) => {
-		const word = by_id(i.id);
-		const keep = [];
-		const removed_notes = [];
-		for (const note of word.notes) {
-			if (note.user === uname && note.date === i.date) {
-				removed_notes.push(note);
-			} else {
-				keep.push(note);
-			}
+actions.removenote = (ret, i, uname) => {
+	if (!uname) return ret(flip('must be logged in'));
+	const e_id = checks.goodid(i.id);
+	if (e_id !== true) return ret(flip(`invalid field 'id': ${e_id}`));
+	const e_date = checks.present(i.date);
+	if (e_date !== true) return ret(flip(`invalid field 'date': ${e_date}`));
+
+	const word = by_id(i.id);
+	const keep = [];
+	const removed_notes = [];
+	for (const note of word.notes) {
+		if (note.user === uname && note.date === i.date) {
+			removed_notes.push(note);
+		} else {
+			keep.push(note);
 		}
-		if (keep.length === word.notes.length) {
-			return ret(flip('no such note by you'));
-		}
-		word.notes = keep;
-		for (const note of removed_notes) {
-			emitter.emit('removenote', word, note);
-		}
-		ret(good({ entry: present(word, uname) }));
-	},
-);
+	}
+	if (keep.length === word.notes.length) {
+		return ret(flip('no such note by you'));
+	}
+	word.notes = keep;
+	for (const note of removed_notes) {
+		emitter.emit('removenote', word, note);
+	}
+	ret(good({ entry: present(word, uname) }));
+};
 
 export const replacements = (s: string): string =>
 	s.replace(/___/g, '▯').replace(/\s+$/g, '').normalize('NFC');

--- a/core/api.ts
+++ b/core/api.ts
@@ -84,25 +84,6 @@ const actions: Record<string, Action> = {};
 const flip = (e: string): ApiError => ({ success: false, error: e });
 const good = (d?: ApiBody): ApiResponse => ({ success: true, ...d });
 
-type Check = (x: any) => true | string;
-
-function guard(
-	logged_in: boolean,
-	conds: Record<string, Check>,
-	f: ActionFunction,
-): Action {
-	const res: Action = (ret, i: object, uname: string | undefined) => {
-		if (logged_in && !uname) return ret(flip('must be logged in'));
-		if (conds)
-			for (const [k, v] of Object.entries(conds)) {
-				const err = v(i[k]);
-				if (err !== true) return ret(flip(`invalid field '${k}'${`: ${err}`}`));
-			}
-		f(ret, i, uname);
-	};
-	return res;
-}
-
 const limit = (lim: number) => (i: unknown) =>
 	!i || typeof i !== 'string'
 		? 'absent'

--- a/core/api.ts
+++ b/core/api.ts
@@ -147,21 +147,28 @@ function present(e: Entry, uname: string | undefined): PresentedEntry {
 
 actions.welcome = (ret, i, uname) => ret(good({ name: uname }));
 
-actions.search = guard(
-	false,
-	{
-		query: checks.present,
-		ordering: checks.optional(checks.nobomb),
-		limit: checks.optional(checks.number),
-		preferred_scope: checks.optional(checks.scope),
-		preferred_scope_bias: checks.optional(checks.number),
-	},
-	(ret, i, uname) => {
-		const data = search.search(i, uname);
-		if (typeof data === 'string') ret(flip(data));
-		else ret(good({ results: data }));
-	},
-);
+actions.search = (ret, i, uname) => {
+	const e_query = checks.present(i.query);
+	if (e_query !== true) return ret(flip(`invalid field 'query': ${e_query}`));
+	const e_ordering = checks.optional(checks.nobomb)(i.ordering);
+	if (e_ordering !== true)
+		return ret(flip(`invalid field 'ordering': ${e_ordering}`));
+	const e_limit = checks.optional(checks.number)(i.limit);
+	if (e_limit !== true) return ret(flip(`invalid field 'limit': ${e_limit}`));
+	const e_preferred_scope = checks.optional(checks.scope)(i.preferred_scope);
+	if (e_preferred_scope !== true)
+		return ret(flip(`invalid field 'preferred_scope': ${e_preferred_scope}`));
+	const e_preferred_scope_bias = checks.optional(checks.number)(
+		i.preferred_scope_bias,
+	);
+	if (e_preferred_scope_bias !== true)
+		return ret(
+			flip(`invalid field 'preferred_scope_bias': ${e_preferred_scope_bias}`),
+		);
+	const data = search.search(i, uname);
+	if (typeof data === 'string') ret(flip(data));
+	else ret(good({ results: data }));
+};
 
 actions.count = (ret, i, uname) => {
 	ret(good({ count: store.db.entries.length }));

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -62,32 +62,6 @@ export function deburrMatch(
 	return count;
 }
 
-const real_setInterval = global.setInterval;
-const real_clearInterval = global.clearInterval;
-
-const interval_cache = [];
-export function setInterval(
-	callback: (...args: any[]) => void,
-	ms?: number,
-): NodeJS.Timer {
-	const this_one = real_setInterval(callback, ms).unref();
-	interval_cache.push(this_one);
-	return this_one;
-}
-
-export function clearInterval(i: string | number | NodeJS.Timeout): void {
-	real_clearInterval(i);
-	const index = interval_cache.indexOf(i);
-	if (index !== -1) interval_cache.splice(index, 1);
-}
-
-export function clearAllIntervals(): void {
-	for (const interval of interval_cache) {
-		clearInterval(interval);
-	}
-	interval_cache.length = 0;
-}
-
 const emitter = new EventEmitter();
 emitter.setMaxListeners(Number.POSITIVE_INFINITY);
 const _emitter = emitter;

--- a/core/server.ts
+++ b/core/server.ts
@@ -251,7 +251,6 @@ function bye(error) {
 	if (error.stack) console.log(`uncaught exception: ${error.stack}`);
 	else console.log(`caught signal ${error}`);
 	console.log('trying to exit gracefully');
-	commons.clearAllIntervals();
 	server.close();
 	for (const connection of connections) {
 		connection.destroy();

--- a/modules/disk.ts
+++ b/modules/disk.ts
@@ -119,8 +119,8 @@ export class DiskModule {
 	) {}
 
 	public up(store: commons.Store): void {
-		commons.setInterval(_ => save(store), this.save_interval);
-		commons.setInterval(_ => backup(store), this.backup_interval);
+		setInterval(_ => save(store), this.save_interval);
+		setInterval(_ => backup(store), this.backup_interval);
 		store.db = read('data/dict.json.gz', { entries: [] });
 		store.pass = read('data/accounts.json.gz', { hashes: {}, tokens: {} });
 	}

--- a/modules/update.ts
+++ b/modules/update.ts
@@ -186,10 +186,7 @@ export class UpdateModule {
 
 	public up(store: commons.Store) {
 		if (this.enabled) {
-			commons.setInterval(
-				() => this.sync_resources(store),
-				this.update_interval,
-			);
+			setInterval(() => this.sync_resources(store), this.update_interval);
 		}
 	}
 }


### PR DESCRIPTION
I think this is a case where [duplication is cheaper than the wrong abstraction](https://sandimetz.com/blog/2016/1/20/the-wrong-abstraction). Not that guard() is _wrong_ per se, but explicitly writing out each check will make the API functions easier to type (in the TypeScript sense) and easier to follow (less "callback hell" / it's completely clear what gets checked where in what order).

This will also help turn this file into a (testable!) `ToaduaApi` class. Right now `checks.goodid` depends on `index_of` which depends on `store` which is a global. Eventually it'll want to be something like `this.goodid` which uses `this.store`. And this refactor will be easier to reason about without having to deal with the overly-abstract `guard`.

For now, I've just tried to mechanically repace every entry like:
```ts
    body: checks.nobomb,
```

with a simple if-return like:
```ts
    const (e_body) = checks.nobomb(i.body);
    if (e_body !== true) return ret(flip(`invalid field 'body': ${e_body}`));
```

Hopefully, this sets up a future PR to get rid of `ret()` and completely eliminate the continuation-passing style from the API.