### PR TITLE
Copy extracted frame/pronoun when presenting entries

### DIFF
--- a/core/commons.ts
+++ b/core/commons.ts
@@ -139,9 +139,9 @@ export interface Entry {
 	/// Total score of the entry, aggregated from votes.
 	score: number;
 	/// The pronominal class of the entry, e.g. `"maq"`.
-	pronominal_class?: string;
+	pronominal_class: string | undefined;
 	/// The frame of the entry, e.g. `"c 1"`.
-	frame?: string;
+	frame: string | undefined;
 }
 
 export interface Token {

--- a/core/search.ts
+++ b/core/search.ts
@@ -40,8 +40,8 @@ interface CachedEntry {
 	notes: string[];
 	date: number;
 	score: number;
-	pronominal_class?: string;
-	frame?: string;
+	pronominal_class: string | undefined;
+	frame: string | undefined;
 	content: string[];
 }
 
@@ -115,6 +115,9 @@ export function present(
 	relevance: number,
 ): PresentedEntry {
 	const { votes, ...rest } = e.$;
+	// `cacheify` may have extracted the pronominal class and frame from the notes:
+	rest.pronominal_class ??= e.pronominal_class;
+	rest.frame ??= e.frame;
 	const vote = uname ? votes[uname] || 0 : undefined;
 	return { ...rest, relevance, content: e.content, vote };
 }

--- a/frontend/shared/index.ts
+++ b/frontend/shared/index.ts
@@ -15,8 +15,8 @@ export interface Entry {
 	scope: string;
 	notes: Note[];
 	score: number;
-	pronominal_class?: string;
-	frame?: string;
+	pronominal_class: string | undefined;
+	frame: string | undefined;
 
 	uncollapsed?: boolean;
 	vote?: number;


### PR DESCRIPTION
Also I think `string | undefined` is less bug-prone than optional fields.