### PR TITLE
Switch to a clearer notation for subject types, e.g. `A` -> `sA`

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -389,8 +389,8 @@ export class Api {
 		const e_pass = limit(128)(i.pass);
 		if (e_pass !== true) return flip(`invalid field 'pass': ${e_pass}`);
 
-		if (process.env.NODE_ENV !== 'development')
-			return flip('registrations are temporarily disabled');
+		// if (process.env.NODE_ENV !== 'development')
+		// 	return flip('registrations are temporarily disabled');
 
 		if (this.store.pass.hashes[i.name]) return flip('already registered');
 		this.store.pass.hashes[i.name] = bcrypt.hashSync(

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -149,7 +149,7 @@ defineProps<{
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.subject ? 1 : 0.5 }"
 					>
-						{{ result.subject ? result.subject[0].toUpperCase() : '—' }}
+						{{ result.subject ? 's' + result.subject[0].toUpperCase() : '—' }}
 					</button>
 					<select
 						v-if="result.frame"
@@ -157,24 +157,24 @@ defineProps<{
 						:disabled="!username"
 						@change="submit_annotation"
 					>
-						<option value="agent">A</option>
+						<option value="agent">sA</option>
 						<option value="" disabled>Subject is a deliberate agent</option>
 						<hr />
-						<option value="individual">I</option>
+						<option value="individual">sI</option>
 						<option value="" disabled>Subject is a non-event</option>
 						<hr />
-						<option :disabled="tangible" value="event">E</option>
+						<option :disabled="tangible" value="event">sE</option>
 						<option value="" disabled>Subject is an event</option>
 						<hr />
-						<option :disabled="tangible" value="predicate">P</option>
+						<option :disabled="tangible" value="predicate">sP</option>
 						<option value="" disabled>Subject is a proposition</option>
 						<hr />
-						<option :disabled="tangible" value="shape">S</option>
+						<option :disabled="tangible" value="shape">sS</option>
 						<option value="" disabled>
 							Subject is spatial (thing or event)
 						</option>
 						<hr />
-						<option :disabled="tangible" value="free">F</option>
+						<option :disabled="tangible" value="free">sF</option>
 						<option value="" disabled>Subject is anything</option>
 					</select>
 				</div>


### PR DESCRIPTION
With time, it's become clear that metadata classes such tend to be used as adjectives, e.g. "**Faq** is hóq." or "I think this ought to be `(c 0)`.", or to otherwise appear unaccompanied in prose. The current short notation for subject types isn't the best for this— when reading in English, it's easy to first read `I` or `A` as a pronoun or article rather than subject types. I conclude that Láqme was on the right track initially with the Si/Sa notation; the main problem with that was the capitalization: it emphasizes "subject" rather than what the actual subject type is. Better, more glance-able, I find sI/sA. Therewith, the eye is drawn to I and to A, which is just what we want to happen. So, I've altered the result template and metadata editor accordingly. This should ensure that, when one sees a subject type written, it's clear what they're looking at regardless of the context.