### PR TITLE
Bring Toadua to annotation parity with official.

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -73,7 +73,19 @@ const DISTRIBUTIONS = [
 
 const SUBJECTS = ['agent', 'individual', 'event', 'predicate', 'shape', 'free'];
 
-const ANNOTATION_FIELDS = ["gloss", "type", "pronominal_class", "frame", "distribution", "subject"];
+const FIXED_ANNOTATION_FIELDS = [
+	'pronominal_class',
+	'frame',
+	'distribution',
+	'subject',
+];
+
+const FIXED_ANNOTATION_FIELD_OPTIONS = {
+	pronominal_class: PRONOMINAL_CLASSES,
+	frame: FRAMES,
+	distribution: DISTRIBUTIONS,
+	subject: SUBJECTS,
+};
 
 export type ApiBody =
 	| { name: string }
@@ -186,8 +198,13 @@ export class Api {
 
 	public async count(i: any, uname: string): Promise<ApiResponse> {
 		const count = this.store.db.entries.length;
-		const annotated = this.store.db.entries.filter(
-			e => ANNOTATION_FIELDS.every((field) => e[field] !== undefined),
+		const annotated = this.store.db.entries.filter(e =>
+			FIXED_ANNOTATION_FIELDS.every(
+				field =>
+					e[field] !== undefined &&
+					e.gloss !== undefined &&
+					e.type !== undefined,
+			),
 		).length;
 		return good({ count, annotated });
 	}
@@ -263,33 +280,38 @@ export class Api {
 		return good({ entry: this.present(word, uname) });
 	}
 
-	// Edit metadata (pronominal class, frame, distribution, subject) on a word.
-	// These can be edited by anyone, not just the owner.
+	// Edit metadata on a word.
+	// These can be edited by anyone, not just the owner (at some point, this may change).
 	public async annotate(i: any, uname: string): Promise<ApiResponse> {
 		if (!uname) return flip('must be logged in');
 		const e_id = this.is_goodid(i.id);
+
 		if (e_id !== true) return flip(`invalid field 'id': ${e_id}`);
-		if (
-			i.pronominal_class &&
-			!PRONOMINAL_CLASSES.includes(i.pronominal_class)
-		) {
-			return flip(`invalid field 'pronominal_class': ${i.pronominal_class}`);
+		const e_gloss = i.gloss !== undefined ? this.is_nobomb(i.gloss) : true;
+		if (e_gloss !== true) return flip(`field 'gloss' is a bomb: ${e_gloss}`);
+		const e_type = i.type !== undefined ? this.is_nobomb(i.type) : true;
+		if (e_type !== true) return flip(`field 'type' is a bomb: ${e_type}`);
+
+		// check that each of the disjoint-union metadata fields has a valid value
+		for (var field of FIXED_ANNOTATION_FIELDS) {
+			if (
+				i[field] &&
+				!FIXED_ANNOTATION_FIELD_OPTIONS[field].includes(i[field])
+			) {
+				return flip(`invalid field '${field}': ${i[field]}`);
+			}
 		}
-		if (i.frame && !FRAMES.includes(i.frame)) {
-			return flip(`invalid field 'frame': ${i.frame}`);
-		}
-		if (i.distribution && !DISTRIBUTIONS.includes(i.distribution)) {
-			return flip(`invalid field 'distribution': ${i.distribution}`);
-		}
-		if (i.subject && !SUBJECTS.includes(i.subject)) {
-			return flip(`invalid field 'subject': ${i.subject}`);
-		}
+
 		const word = this.by_id(i.id);
 		if (!word) return flip('no such word');
+
 		word.pronominal_class = i.pronominal_class;
 		word.frame = i.frame;
 		word.distribution = i.distribution;
 		word.subject = i.subject;
+		word.gloss = i.gloss;
+		word.type = i.type;
+
 		emitter.emit('annotate', word);
 		return good({ entry: this.present(word, uname) });
 	}
@@ -330,14 +352,22 @@ export class Api {
 		const e_scope = this.is_scope(i.scope);
 		if (e_scope !== true) return flip(`invalid field 'scope': ${e_scope}`);
 
-		// Abort if an entry with exactly the same head, body, and scope exists
+		// Abort if an entry with exactly the data exists
 		const normalizedHead = shared.normalize(i.head);
+		let normalizedGloss =
+			i.gloss !== undefined ? replacements(i.gloss) : undefined;
 		const normalizedBody = replacements(i.body);
 		const scope = i.scope;
+
+		const normalizedType =
+			i.type !== undefined ? replacements(i.type) : undefined;
+
 		const exists = this.store.db.entries.some(
 			e =>
 				e.head === normalizedHead &&
+				e.gloss == normalizedGloss &&
 				e.body === normalizedBody &&
+				e.type === normalizedType &&
 				e.frame === i.frame &&
 				e.pronominal_class === i.pronominal_class &&
 				e.subject === i.subject &&
@@ -352,12 +382,14 @@ export class Api {
 			id,
 			date: new Date().toISOString(),
 			head: normalizedHead,
+			gloss: normalizedGloss,
 			body: normalizedBody,
 			user: uname,
 			scope: i.scope,
 			notes: [],
 			votes: {},
 			score: 0,
+			type: normalizedType,
 			pronominal_class: i.pronominal_class,
 			frame: i.frame,
 			distribution: i.distribution,

--- a/core/api.ts
+++ b/core/api.ts
@@ -73,6 +73,8 @@ const DISTRIBUTIONS = [
 
 const SUBJECTS = ['agent', 'individual', 'event', 'predicate', 'shape', 'free'];
 
+const ANNOTATION_FIELDS = ["gloss", "type", "pronominal_class", "frame", "distribution", "subject"];
+
 export type ApiBody =
 	| { name: string }
 	| { entry: PresentedEntry }
@@ -185,7 +187,7 @@ export class Api {
 	public async count(i: any, uname: string): Promise<ApiResponse> {
 		const count = this.store.db.entries.length;
 		const annotated = this.store.db.entries.filter(
-			e => e.pronominal_class !== undefined,
+			e => ANNOTATION_FIELDS.every((field) => e[field] !== undefined),
 		).length;
 		return good({ count, annotated });
 	}

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -126,7 +126,7 @@ export interface Entry {
 	/// The Toaq word this entry is for.
 	head: string;
 	/// The gloss of the word.
-	// gloss?: string;
+	gloss: string | undefined;
 	/// The definition of the word.
 	body: string;
 	/// The name of the user that added the entry.
@@ -140,7 +140,7 @@ export interface Entry {
 	/// Total score of the entry, aggregated from votes.
 	score: number;
 	/// The type of the entry, e.g. `"predicate"`.
-	// type: string | undefined;
+	type: string | undefined;
 	/// The pronominal class of the entry, e.g. `"maq"`.
 	pronominal_class: string | undefined;
 	/// The frame of the entry, e.g. `"c 1"`.

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -125,6 +125,8 @@ export interface Entry {
 	date: string;
 	/// The Toaq word this entry is for.
 	head: string;
+	/// The gloss of the word.
+	// gloss?: string;
 	/// The definition of the word.
 	body: string;
 	/// The name of the user that added the entry.
@@ -137,6 +139,8 @@ export interface Entry {
 	votes: Record<string, -1 | 0 | 1>;
 	/// Total score of the entry, aggregated from votes.
 	score: number;
+	/// The type of the entry, e.g. `"predicate"`.
+	// type: string | undefined;
 	/// The pronominal class of the entry, e.g. `"maq"`.
 	pronominal_class: string | undefined;
 	/// The frame of the entry, e.g. `"c 1"`.

--- a/modules/housekeep.test.ts
+++ b/modules/housekeep.test.ts
@@ -19,6 +19,8 @@ const makeEntry = (overrides: Partial<commons.Entry> = {}): commons.Entry => ({
 	frame: undefined,
 	distribution: undefined,
 	subject: undefined,
+	gloss: undefined,
+	type: undefined,
 	...overrides,
 });
 

--- a/modules/update.test.ts
+++ b/modules/update.test.ts
@@ -234,6 +234,8 @@ describe('UpdateModule', () => {
 				frame: undefined,
 				distribution: undefined,
 				subject: undefined,
+				gloss: undefined,
+				type: undefined,
 			});
 
 			mockStore.db.entries.push(
@@ -254,6 +256,8 @@ describe('UpdateModule', () => {
 					frame: 'c 1',
 					distribution: 'd',
 					subject: 'agent',
+					gloss: 'utter',
+					type: 'predicate'
 				},
 				{
 					...stale('off2', 'official', 'geo', 'verb: ‘old’; to be old'),


### PR DESCRIPTION
I want to add `gloss` and `type` fields so that [toaq/dictionary](https://github.com/toaq/dictionary/) words can be represented losslessly in Toadua and to eliminate the present kludginess of Toadua's `pronominal_class` taking on the duties of official's `type`.

I've gone ahead and done what I think needs to be done on the backend to make that happen— someone more familiar with the code-base should check my work there. I've also changed the behavior of the API funtion `count` to only consider a definition annotated when _all_ fields are filled (rather than considering just `pronominal_class`), and made a couple very minor refactors.

Opening this as draft, since clearly there's work to be done; I just want to make it visible.

Edit: To be clear, I don't mean I've already done _everything_ that needs to be done on the backend, but have gotten a start at it.