### PR TITLE
Add `type` and `gloss` fields

### DIFF
--- a/config/sources-prod.yml
+++ b/config/sources-prod.yml
@@ -6,7 +6,7 @@ delta_examples:
   patterns:
     - head: '%(1)'
       body: '%(2)'
-      pronominal_class: 'phrase'
+      type: 'phrase'
 a_examples:
   user: examples
   source: 'https://docs.google.com/spreadsheets/d/1bCQoaX02ZyaElHiiMcKHFemO4eV1MEYmYloYZgOAhac/export?format=tsv&id=1bCQoaX02ZyaElHiiMcKHFemO4eV1MEYmYloYZgOAhac&gid=1211677603'
@@ -15,7 +15,7 @@ a_examples:
   patterns:
     - head: '%(1)'
       body: '%(2)'
-      pronominal_class: 'phrase'
+      type: 'phrase'
 b_examples:
   user: examples
   source: 'https://docs.google.com/spreadsheets/d/1bCQoaX02ZyaElHiiMcKHFemO4eV1MEYmYloYZgOAhac/export?format=tsv&id=1bCQoaX02ZyaElHiiMcKHFemO4eV1MEYmYloYZgOAhac&gid=574044693'
@@ -24,7 +24,7 @@ b_examples:
   patterns:
     - head: '%(1)'
       body: '(%(0)) %(2)'
-      pronominal_class: 'phrase'
+      type: 'phrase'
 countries:
   user: countries
   source: 'https://docs.google.com/spreadsheets/d/1P9p1D38p364JSiNqLMGwY3zDRPQ_f6Yob_OL-uku28Q/export?format=tsv&id=1P9p1D38p364JSiNqLMGwY3zDRPQ_f6Yob_OL-uku28Q&gid=637793855'
@@ -33,12 +33,14 @@ countries:
   patterns:
     - head: '%(1)'
       body: '___ pertains to the culture of %(0).'
+      type: 'predicate'
       pronominal_class: 'ta'
       frame: 'c'
       distribution: 'd'
       subject: 'free'
     - head: '%(2)'
       body: '___ is the country %(0).'
+      type: 'predicate'
       pronominal_class: 'maq'
       frame: 'c'
       distribution: 'n'

--- a/config/sources-prod.yml
+++ b/config/sources-prod.yml
@@ -49,7 +49,9 @@ official:
   format: json
   patterns:
     - head: '%(toaq)'
-      body: '%(type): ‘%(gloss)’; %(english)'
+      gloss: '%(gloss)'
+      body: '%(english)'
+      type: '%(type)'
       frame: '%(frame)'
       pronominal_class: '%(pronominal_class)'
       subject: '%(subject)'

--- a/core/api.ts
+++ b/core/api.ts
@@ -200,9 +200,10 @@ export class Api {
 		const count = this.store.db.entries.length;
 		const annotated = this.store.db.entries.filter(
 			e =>
-				FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined) &&
 				e.gloss !== undefined &&
-				e.type !== undefined,
+				(e.type === 'predicate'
+					? FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined)
+					: e.type !== undefined),
 		).length;
 		return good({ count, annotated });
 	}

--- a/core/api.ts
+++ b/core/api.ts
@@ -1,7 +1,7 @@
 // api.ts
 // implementation for the API
 
-import { config, emitter } from './commons.js';
+import { emitter, isAnnotated } from './commons.js';
 import type { Entry, Store, ToaduaConfig } from './commons.js';
 import { Search } from './search.js';
 import * as shared from '../frontend/shared/index.js';
@@ -15,9 +15,9 @@ import type { PresentedEntry } from './search.js';
 // Workaround for bcryptjs' broken types
 const bcrypt = bcryptjs as typeof bcryptjs_types;
 
-const PRONOMINAL_CLASSES = ['ho', 'maq', 'hoq', 'ta', 'raı'];
+export const PRONOMINAL_CLASSES = ['ho', 'maq', 'hoq', 'ta', 'raı'];
 
-const FRAMES = [
+export const FRAMES = [
 	'c',
 	'c c',
 	'c c c',
@@ -46,7 +46,7 @@ const FRAMES = [
 	'c c 2xx',
 ];
 
-const DISTRIBUTIONS = [
+export const DISTRIBUTIONS = [
 	'd',
 	'n',
 	'd d',
@@ -63,9 +63,16 @@ const DISTRIBUTIONS = [
 	'n n n',
 ];
 
-const SUBJECTS = ['agent', 'individual', 'event', 'predicate', 'shape', 'free'];
+export const SUBJECTS = [
+	'agent',
+	'individual',
+	'event',
+	'predicate',
+	'shape',
+	'free',
+];
 
-const FIXED_ANNOTATION_FIELDS = [
+export const FIXED_ANNOTATION_FIELDS = [
 	'pronominal_class',
 	'frame',
 	'distribution',
@@ -189,15 +196,10 @@ export class Api {
 	}
 
 	public async count(i: any, uname: string): Promise<ApiResponse> {
-		const count = this.store.db.entries.length;
-		const annotated = this.store.db.entries.filter(
-			e =>
-				(e.gloss || e.type === 'phrase') &&
-				(e.type === 'predicate' && e.body.includes('▯')
-					? FIXED_ANNOTATION_FIELDS.every(field => e[field])
-					: e.type),
-		).length;
-		return good({ count, annotated });
+		return good({
+			count: this.store.db.entries.length,
+			annotated: this.store.db.entries.filter(isAnnotated).length,
+		});
 	}
 
 	public async vote(i: any, uname: string): Promise<ApiResponse> {

--- a/core/api.ts
+++ b/core/api.ts
@@ -198,13 +198,11 @@ export class Api {
 
 	public async count(i: any, uname: string): Promise<ApiResponse> {
 		const count = this.store.db.entries.length;
-		const annotated = this.store.db.entries.filter(e =>
-			FIXED_ANNOTATION_FIELDS.every(
-				field =>
-					e[field] !== undefined &&
-					e.gloss !== undefined &&
-					e.type !== undefined,
-			),
+		const annotated = this.store.db.entries.filter(
+			e =>
+				FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined) &&
+				e.gloss !== undefined &&
+				e.type !== undefined,
 		).length;
 		return good({ count, annotated });
 	}

--- a/core/api.ts
+++ b/core/api.ts
@@ -192,10 +192,10 @@ export class Api {
 		const count = this.store.db.entries.length;
 		const annotated = this.store.db.entries.filter(
 			e =>
-				(e.gloss !== undefined || e.type === 'phrase') &&
+				(e.gloss || e.type === 'phrase') &&
 				(e.type === 'predicate' && e.body.includes('▯')
-					? FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined)
-					: e.type !== undefined),
+					? FIXED_ANNOTATION_FIELDS.every(field => e[field])
+					: e.type),
 		).length;
 		return good({ count, annotated });
 	}
@@ -278,9 +278,9 @@ export class Api {
 		const e_id = this.is_goodid(i.id);
 
 		if (e_id !== true) return flip(`invalid field 'id': ${e_id}`);
-		const e_gloss = i.gloss !== undefined ? this.is_nobomb(i.gloss) : true;
+		const e_gloss = i.gloss ? this.is_nobomb(i.gloss) : true;
 		if (e_gloss !== true) return flip(`field 'gloss' is a bomb: ${e_gloss}`);
-		const e_type = i.type !== undefined ? this.is_nobomb(i.type) : true;
+		const e_type = i.type ? this.is_nobomb(i.type) : true;
 		if (e_type !== true) return flip(`field 'type' is a bomb: ${e_type}`);
 
 		// check that each of the disjoint-union metadata fields has a valid value

--- a/core/api.ts
+++ b/core/api.ts
@@ -73,6 +73,20 @@ const DISTRIBUTIONS = [
 
 const SUBJECTS = ['agent', 'individual', 'event', 'predicate', 'shape', 'free'];
 
+const FIXED_ANNOTATION_FIELDS = [
+	'pronominal_class',
+	'frame',
+	'distribution',
+	'subject',
+];
+
+const FIXED_ANNOTATION_FIELD_OPTIONS = {
+	pronominal_class: PRONOMINAL_CLASSES,
+	frame: FRAMES,
+	distribution: DISTRIBUTIONS,
+	subject: SUBJECTS,
+};
+
 export type ApiBody =
 	| { name: string }
 	| { entry: PresentedEntry }
@@ -184,8 +198,13 @@ export class Api {
 
 	public async count(i: any, uname: string): Promise<ApiResponse> {
 		const count = this.store.db.entries.length;
-		const annotated = this.store.db.entries.filter(
-			e => e.pronominal_class !== undefined,
+		const annotated = this.store.db.entries.filter(e =>
+			FIXED_ANNOTATION_FIELDS.every(
+				field =>
+					e[field] !== undefined &&
+					e.gloss !== undefined &&
+					e.type !== undefined,
+			),
 		).length;
 		return good({ count, annotated });
 	}
@@ -261,33 +280,38 @@ export class Api {
 		return good({ entry: this.present(word, uname) });
 	}
 
-	// Edit metadata (pronominal class, frame, distribution, subject) on a word.
-	// These can be edited by anyone, not just the owner.
+	// Edit metadata on a word.
+	// These can be edited by anyone, not just the owner (at some point, this may change).
 	public async annotate(i: any, uname: string): Promise<ApiResponse> {
 		if (!uname) return flip('must be logged in');
 		const e_id = this.is_goodid(i.id);
+
 		if (e_id !== true) return flip(`invalid field 'id': ${e_id}`);
-		if (
-			i.pronominal_class &&
-			!PRONOMINAL_CLASSES.includes(i.pronominal_class)
-		) {
-			return flip(`invalid field 'pronominal_class': ${i.pronominal_class}`);
+		const e_gloss = i.gloss !== undefined ? this.is_nobomb(i.gloss) : true;
+		if (e_gloss !== true) return flip(`field 'gloss' is a bomb: ${e_gloss}`);
+		const e_type = i.type !== undefined ? this.is_nobomb(i.type) : true;
+		if (e_type !== true) return flip(`field 'type' is a bomb: ${e_type}`);
+
+		// check that each of the disjoint-union metadata fields has a valid value
+		for (var field of FIXED_ANNOTATION_FIELDS) {
+			if (
+				i[field] &&
+				!FIXED_ANNOTATION_FIELD_OPTIONS[field].includes(i[field])
+			) {
+				return flip(`invalid field '${field}': ${i[field]}`);
+			}
 		}
-		if (i.frame && !FRAMES.includes(i.frame)) {
-			return flip(`invalid field 'frame': ${i.frame}`);
-		}
-		if (i.distribution && !DISTRIBUTIONS.includes(i.distribution)) {
-			return flip(`invalid field 'distribution': ${i.distribution}`);
-		}
-		if (i.subject && !SUBJECTS.includes(i.subject)) {
-			return flip(`invalid field 'subject': ${i.subject}`);
-		}
+
 		const word = this.by_id(i.id);
 		if (!word) return flip('no such word');
+
 		word.pronominal_class = i.pronominal_class;
 		word.frame = i.frame;
 		word.distribution = i.distribution;
 		word.subject = i.subject;
+		word.gloss = i.gloss;
+		word.type = i.type;
+
 		emitter.emit('annotate', word);
 		return good({ entry: this.present(word, uname) });
 	}
@@ -328,14 +352,22 @@ export class Api {
 		const e_scope = this.is_scope(i.scope);
 		if (e_scope !== true) return flip(`invalid field 'scope': ${e_scope}`);
 
-		// Abort if an entry with exactly the same head, body, and scope exists
+		// Abort if an entry with exactly the data exists
 		const normalizedHead = shared.normalize(i.head);
+		let normalizedGloss =
+			i.gloss !== undefined ? replacements(i.gloss) : undefined;
 		const normalizedBody = replacements(i.body);
 		const scope = i.scope;
+
+		const normalizedType =
+			i.type !== undefined ? replacements(i.type) : undefined;
+
 		const exists = this.store.db.entries.some(
 			e =>
 				e.head === normalizedHead &&
+				e.gloss == normalizedGloss &&
 				e.body === normalizedBody &&
+				e.type === normalizedType &&
 				e.frame === i.frame &&
 				e.pronominal_class === i.pronominal_class &&
 				e.subject === i.subject &&
@@ -350,12 +382,14 @@ export class Api {
 			id,
 			date: new Date().toISOString(),
 			head: normalizedHead,
+			gloss: normalizedGloss,
 			body: normalizedBody,
 			user: uname,
 			scope: i.scope,
 			notes: [],
 			votes: {},
 			score: 0,
+			type: normalizedType,
 			pronominal_class: i.pronominal_class,
 			frame: i.frame,
 			distribution: i.distribution,

--- a/core/api.ts
+++ b/core/api.ts
@@ -192,7 +192,7 @@ export class Api {
 		const count = this.store.db.entries.length;
 		const annotated = this.store.db.entries.filter(
 			e =>
-				e.gloss !== undefined &&
+				(e.gloss !== undefined || e.type === 'phrase') &&
 				(e.type === 'predicate'
 					? FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined)
 					: e.type !== undefined),

--- a/core/api.ts
+++ b/core/api.ts
@@ -193,7 +193,7 @@ export class Api {
 		const annotated = this.store.db.entries.filter(
 			e =>
 				(e.gloss !== undefined || e.type === 'phrase') &&
-				(e.type === 'predicate'
+				(e.type === 'predicate' && e.body.includes("▯")
 					? FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined)
 					: e.type !== undefined),
 		).length;

--- a/core/api.ts
+++ b/core/api.ts
@@ -355,12 +355,12 @@ export class Api {
 		// Abort if an entry with exactly the data exists
 		const normalizedHead = shared.normalize(i.head);
 		let normalizedGloss =
-			i.gloss !== undefined ? replacements(i.gloss) : undefined;
+			i.gloss !== undefined ? i.gloss.normalize('NFC') : undefined;
 		const normalizedBody = replacements(i.body);
 		const scope = i.scope;
 
 		const normalizedType =
-			i.type !== undefined ? replacements(i.type) : undefined;
+			i.type !== undefined ? i.type.normalize('NFC') : undefined;
 
 		const exists = this.store.db.entries.some(
 			e =>

--- a/core/api.ts
+++ b/core/api.ts
@@ -193,7 +193,7 @@ export class Api {
 		const annotated = this.store.db.entries.filter(
 			e =>
 				(e.gloss !== undefined || e.type === 'phrase') &&
-				(e.type === 'predicate' && e.body.includes("▯")
+				(e.type === 'predicate' && e.body.includes('▯')
 					? FIXED_ANNOTATION_FIELDS.every(field => e[field] !== undefined)
 					: e.type !== undefined),
 		).length;

--- a/core/api.ts
+++ b/core/api.ts
@@ -15,15 +15,7 @@ import type { PresentedEntry } from './search.js';
 // Workaround for bcryptjs' broken types
 const bcrypt = bcryptjs as typeof bcryptjs_types;
 
-const PRONOMINAL_CLASSES = [
-	'ho',
-	'maq',
-	'hoq',
-	'ta',
-	'raı',
-	'particle',
-	'phrase',
-];
+const PRONOMINAL_CLASSES = ['ho', 'maq', 'hoq', 'ta', 'raı'];
 
 const FRAMES = [
 	'c',

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -57,6 +57,17 @@ export function isAnnotated(e: CommonEntry): boolean {
 	);
 }
 
+// this may be useful in the front-end for `guess_other_metadata` or such
+export function tryAssessType(e: CommonEntry): string | undefined {
+	let guess: string[] = [];
+
+	if (e.head[0] === '-') guess.push('pseudo-suffix');
+	if (e.head[e.head.length - 1] === '-') guess.push('prefix');
+	if (e.body.includes('▯')) guess.push('predicate');
+
+	return guess.length === 1 ? guess[0] : undefined;
+}
+
 export function deburrMatch(
 	what: string[],
 	where: string[],

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -125,6 +125,8 @@ export interface Entry {
 	date: string;
 	/// The Toaq word this entry is for.
 	head: string;
+	/// The gloss of the word.
+	gloss: string | undefined;
 	/// The definition of the word.
 	body: string;
 	/// The name of the user that added the entry.
@@ -137,6 +139,8 @@ export interface Entry {
 	votes: Record<string, -1 | 0 | 1>;
 	/// Total score of the entry, aggregated from votes.
 	score: number;
+	/// The type of the entry, e.g. `"predicate"`.
+	type: string | undefined;
 	/// The pronominal class of the entry, e.g. `"maq"`.
 	pronominal_class: string | undefined;
 	/// The frame of the entry, e.g. `"c 1"`.

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import * as yaml from 'js-yaml';
 import { EventEmitter } from 'node:events';
 import { cwd } from 'node:process';
+import { FIXED_ANNOTATION_FIELDS } from './api.js';
 
 const old_log = console.log;
 
@@ -45,6 +46,15 @@ export enum MatchMode {
 	Containing = 0,
 	Contained = 1,
 	Exact = 2,
+}
+
+export function isAnnotated(e: CommonEntry): boolean {
+	return (
+		(e.gloss || e.type === 'phrase') &&
+		(e.type === 'predicate' && e.body.includes('▯')
+			? FIXED_ANNOTATION_FIELDS.every(field => e[field])
+			: !!e.type)
+	);
 }
 
 export function deburrMatch(
@@ -118,27 +128,13 @@ export interface Note {
 	content: string;
 }
 
-export interface Entry {
-	/// An entry ID string like `AbCdEfGhI`.
-	id: string;
-	/// An ISO 8601 date string like `2022-12-28T21:38:31.682Z`.
-	date: string;
+export interface CommonEntry {
 	/// The Toaq word this entry is for.
 	head: string;
 	/// The gloss of the word.
 	gloss: string | undefined;
 	/// The definition of the word.
 	body: string;
-	/// The name of the user that added the entry.
-	user: string;
-	/// The scope (`en`, `toa`...) the entry is in.
-	scope: string;
-	/// Notes left on this entry.
-	notes: Note[];
-	/// Map from usernames to individual votes.
-	votes: Record<string, -1 | 0 | 1>;
-	/// Total score of the entry, aggregated from votes.
-	score: number;
 	/// The type of the entry, e.g. `"predicate"`.
 	type: string | undefined;
 	/// The pronominal class of the entry, e.g. `"maq"`.
@@ -149,6 +145,23 @@ export interface Entry {
 	distribution: string | undefined;
 	/// The subject of the entry: `"agent"`, `"individual"`, `"event"`, `"predicate"`, `"shape"`, or `"free"`.
 	subject: string | undefined;
+}
+
+export interface Entry extends CommonEntry {
+	/// An entry ID string like `AbCdEfGhI`.
+	id: string;
+	/// An ISO 8601 date string like `2022-12-28T21:38:31.682Z`.
+	date: string;
+	/// The name of the user that added the entry.
+	user: string;
+	/// The scope (`en`, `toa`...) the entry is in.
+	scope: string;
+	/// Notes left on this entry.
+	notes: Note[];
+	/// Map from usernames to individual votes.
+	votes: Record<string, -1 | 0 | 1>;
+	/// Total score of the entry, aggregated from votes.
+	score: number;
 }
 
 export interface Token {

--- a/core/search.ts
+++ b/core/search.ts
@@ -18,10 +18,12 @@ interface CachedEntry {
 	$: Entry;
 	id: string;
 	head: string[];
+	gloss: string | undefined;
 	body: string[];
 	notes: string[];
 	date: number;
 	score: number;
+	type: string | undefined;
 	pronominal_class: string | undefined;
 	frame: string | undefined;
 	distribution: string | undefined;
@@ -36,6 +38,7 @@ export interface PresentedEntry extends Omit<Entry, 'votes'> {
 	content?: string[];
 }
 
+// should this include metadata fields? (- Démbım)
 const RE_TRAITS = [
 	'id',
 	'user',
@@ -126,6 +129,16 @@ export function extract_subject(notes: Note[]): string | undefined {
 	return undefined;
 }
 
+// stub
+export function extract_gloss(notes: Note[]): string | undefined {
+	return undefined;
+}
+
+// stub
+export function extract_type(notes: Note[]): string | undefined {
+	return undefined;
+}
+
 export function score(entry: Entry): number {
 	const votes: [string, number][] = Object.entries(entry.votes);
 	return votes.reduce((a, b) => a + b[1], 0);
@@ -140,10 +153,12 @@ export function cacheify(e: Entry): CachedEntry {
 		$: e,
 		id: e.id,
 		head: deburredHead,
+		gloss: e.gloss ?? extract_gloss(e.notes),
 		body: deburredBody,
 		notes: deburredNotes,
 		date: +new Date(e.date),
 		score: e.score,
+		type: e.type ?? extract_type(e.notes),
 		pronominal_class: e.pronominal_class ?? extract_pronominal_class(e.notes),
 		frame: e.frame ?? extract_frame(e.notes),
 		distribution: e.distribution ?? extract_distribution(e.notes),
@@ -163,6 +178,10 @@ export function present(
 	rest.frame ??= e.frame;
 	rest.distribution ??= e.distribution;
 	rest.subject ??= e.subject;
+
+	rest.gloss ??= e.gloss;
+	rest.type ??= e.type;
+
 	const vote = uname ? votes[uname] || 0 : undefined;
 	return { ...rest, relevance, content: e.content, vote };
 }
@@ -363,8 +382,9 @@ export class Search {
 		// Spaces are stripped for comparison, so e.g. frame:c1i matches stored "c 1i".
 		const metaFieldAliases: [
 			string,
-			'pronominal_class' | 'frame' | 'distribution' | 'subject',
+			'type' | 'pronominal_class' | 'frame' | 'distribution' | 'subject',
 		][] = [
+			['type', 'type'],
 			['pronominal_class', 'pronominal_class'],
 			['pronoun', 'pronominal_class'],
 			['animacy', 'pronominal_class'],

--- a/core/search.ts
+++ b/core/search.ts
@@ -11,7 +11,9 @@ import {
 	type Entry,
 	Note,
 	type Store,
+	isAnnotated,
 } from './commons.js';
+import { PRONOMINAL_CLASSES, SUBJECTS } from './api.js';
 
 // keep an own cache for entries
 interface CachedEntry {
@@ -67,9 +69,7 @@ export function extract_pronominal_class(notes: Note[]): string | undefined {
 				.normalize('NFD')
 				.replace(/[\u0300-\u036f]/g, '')
 				.replace('i', 'ı');
-			if (
-				['ho', 'maq', 'hoq', 'ta', 'raı', 'particle', 'phrase'].includes(value)
-			) {
+			if (PRONOMINAL_CLASSES.includes(value)) {
 				return value;
 			}
 		}
@@ -108,20 +108,12 @@ export function extract_distribution(notes: Note[]): string | undefined {
 }
 
 export function extract_subject(notes: Note[]): string | undefined {
-	const validSubjects = [
-		'agent',
-		'individual',
-		'event',
-		'predicate',
-		'shape',
-		'free',
-	];
 	for (let i = notes.length - 1; i >= 0; i--) {
 		const note = notes[i];
 		const match = note.content.toLowerCase().match(/subject\s*:\s*(.*)/);
 		if (match) {
 			const value = match[1].trim();
-			if (validSubjects.includes(value)) {
+			if (SUBJECTS.includes(value)) {
 				return value;
 			}
 		}
@@ -355,6 +347,14 @@ export class Search {
 					([vote], uname) =>
 					entry =>
 						uname ? (entry.$.votes[uname] || 0) === vote : false,
+			},
+			complete: {
+				type: OperationType.Other,
+				check: args => args.length === 1 && typeof args[0] === 'boolean',
+				build:
+					([b]) =>
+					entry =>
+						b === isAnnotated(entry.$),
 			},
 			before: {
 				type: OperationType.Other,

--- a/core/search.ts
+++ b/core/search.ts
@@ -382,8 +382,9 @@ export class Search {
 		// Spaces are stripped for comparison, so e.g. frame:c1i matches stored "c 1i".
 		const metaFieldAliases: [
 			string,
-			'type' | 'pronominal_class' | 'frame' | 'distribution' | 'subject',
+			'gloss' | 'type' | 'pronominal_class' | 'frame' | 'distribution' | 'subject',
 		][] = [
+			['gloss', 'gloss'],
 			['type', 'type'],
 			['pronominal_class', 'pronominal_class'],
 			['pronoun', 'pronominal_class'],

--- a/core/search.ts
+++ b/core/search.ts
@@ -141,6 +141,7 @@ export function cacheify(e: Entry): CachedEntry {
 	const deburredHead = deburr(e.head);
 	const deburredBody = deburr(e.body);
 	const deburredNotes = e.notes.flatMap(({ content }) => deburr(content));
+	const deburredGloss = e.gloss ? deburr(e.gloss) : [];
 	return {
 		$: e,
 		id: e.id,
@@ -155,7 +156,12 @@ export function cacheify(e: Entry): CachedEntry {
 		frame: e.frame ?? extract_frame(e.notes),
 		distribution: e.distribution ?? extract_distribution(e.notes),
 		subject: e.subject ?? extract_subject(e.notes),
-		content: [].concat(deburredHead, deburredBody, deburredNotes),
+		content: [].concat(
+			deburredHead,
+			deburredGloss,
+			deburredBody,
+			deburredNotes,
+		),
 	};
 }
 

--- a/core/search.ts
+++ b/core/search.ts
@@ -382,7 +382,14 @@ export class Search {
 		// Spaces are stripped for comparison, so e.g. frame:c1i matches stored "c 1i".
 		const metaFieldAliases: [
 			string,
-			'gloss' | 'type' | 'pronominal_class' | 'frame' | 'distribution' | 'subject',
+			(
+				| 'gloss'
+				| 'type'
+				| 'pronominal_class'
+				| 'frame'
+				| 'distribution'
+				| 'subject'
+			),
 		][] = [
 			['gloss', 'gloss'],
 			['type', 'type'],

--- a/core/server.ts
+++ b/core/server.ts
@@ -40,6 +40,13 @@ const VERSION = JSON.parse(
 ).version;
 console.log(`starting up v${VERSION}...`);
 
+const modules_names = Object.keys(commons.config.modules);
+console.log(
+	`loaded ${modules_names.length} modules${
+		modules_names.length === 0 ? '' : `: ${JSON.stringify(modules_names)}`
+	}`,
+);
+
 import * as http from 'node:http';
 import { Api } from './api.js';
 import { Search } from './search.js';

--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -64,8 +64,16 @@
 			@removenote="date => removenote(result, date)"
 			@edit="(body, scope) => edit(result, body, scope)"
 			@annotate="
-				(pronominal_class, frame, distribution, subject) =>
-					annotate(result, pronominal_class, frame, distribution, subject)
+				(gloss, type, pronominal_class, frame, distribution, subject) =>
+					annotate(
+						result,
+						gloss,
+						type,
+						pronominal_class,
+						frame,
+						distribution,
+						subject,
+					)
 			"
 			@uncollapse="uncollapseOnly(result)"
 			@vote="n => vote(result, n)"
@@ -428,6 +436,8 @@ export default defineComponent({
 
 		annotate(
 			whom: Entry,
+			gloss: string,
+			type: string,
 			pronominal_class: string,
 			frame: string,
 			distribution: string,
@@ -435,6 +445,8 @@ export default defineComponent({
 		): void {
 			// Update the entry early to prevent a flash of the old annotations...
 			this.update_entry(whom, {
+				gloss,
+				type,
 				pronominal_class,
 				frame,
 				distribution,
@@ -444,6 +456,8 @@ export default defineComponent({
 				{
 					action: 'annotate',
 					id: whom.id,
+					gloss,
+					type,
 					pronominal_class,
 					frame,
 					distribution,

--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -501,8 +501,11 @@ export default defineComponent({
 		},
 
 		update_entry(whom: Entry, what_with: Partial<Entry>): void {
-			for (const p in what_with)
-				if (Object.hasOwn(what_with, p)) whom[p] = what_with[p];
+			for (const p in what_with) {
+				if (Object.hasOwn(what_with, p)) {
+					whom[p] = what_with[p];
+				}
+			}
 		},
 
 		new_word(): void {

--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -239,7 +239,7 @@
 				v-if="username"
 				style="float: right"
 				href="javascript:void(0)"
-				@click="navigate('pronoun:none')"
+				@click="navigate('complete:false')"
 				>help out</a
 			>
 		</span>

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -21,16 +21,20 @@ defineProps<{
 				>
 			</h2>
 			<div class="info">
-				<input
-					v-if="editing"
-					type="text"
-					size="5"
-					v-model="new_scope"
-					class="scope editing"
-					autocomplete="language"
-					list="common-languages"
-					@keypress.enter.exact.prevent="submit_edit"
-				/>
+				<template v-if="editing">
+					<input
+						v-if="username === result.user"
+						type="text"
+						size="5"
+						v-model="new_scope"
+						class="scope editing"
+						autocomplete="language"
+						list="common-languages"
+						@keypress.enter.exact.prevent="submit_edit"
+					/>
+					<span v-else class="scope">{{ result.scope }}</span>
+				</template>
+
 				<a
 					v-if="!editing && !limit_search"
 					:href="'#scope:' + result.scope"
@@ -202,7 +206,9 @@ defineProps<{
 					@keypress.enter.exact.prevent="submit_edit"
 				/>
 			</div>
+
 			<textarea
+				v-if="username === result.user"
 				v-focus
 				class="body editing"
 				rows="1"
@@ -216,6 +222,7 @@ defineProps<{
 				spellcheck="true"
 				style="width: 100%; margin: 0"
 			></textarea>
+			<p v-else class="body" v-html="fancy_body" style="margin: 0"></p>
 		</div>
 		<p v-else class="body" v-html="fancy_body"></p>
 
@@ -311,7 +318,7 @@ defineProps<{
 							<font-awesome-icon icon="code-branch" />
 						</button>
 					</div>
-					<div v-if="!editing && username == result.user">
+					<div v-if="!editing && username">
 						<button
 							type="button"
 							aria-label="Edit"
@@ -457,7 +464,9 @@ export default defineComponent({
 		},
 
 		submit_edit(): void {
-			this.$emit('edit', this.new_body, this.new_scope);
+			if (this.username === this.result.user) {
+				this.$emit('edit', this.new_body, this.new_scope);
+			}
 			if (this.new_type === 'predicate') {
 				this.$emit(
 					'annotate',
@@ -571,7 +580,6 @@ export default defineComponent({
 				fancy_content: shared.replacements(content, false, false, this.theme),
 			}));
 		},
-		// TODO: make `type` and `gloss` editable
 		any_editable_metadata(): boolean {
 			return !!(
 				this.result.pronominal_class ||

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -45,7 +45,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Pronominal class"
-						v-if="!is_non_verb"
+						v-if="!is_non_verb && !is_nullary_verb"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.pronominal_class ? 1 : 0.5 }"
@@ -68,12 +68,13 @@ defineProps<{
 						<option value="maq">máq</option>
 						<option value="hoq">hóq</option>
 						<option value="ta">tá</option>
+						<option value="">—</option>
 					</select>
 				</div>
 				<div style="position: relative">
 					<button
 						title="Frame"
-						v-if="any_editable_metadata && !is_non_verb"
+						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.frame ? 1 : 0.5 }"
@@ -82,7 +83,7 @@ defineProps<{
 					</button>
 					<select
 						title="Frame"
-						v-if="any_editable_metadata && !is_non_verb"
+						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
 						v-model="result.frame"
 						:disabled="!username"
 						@change="submit_annotation"
@@ -112,7 +113,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Distribution"
-						v-if="result.frame"
+						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.distribution ? 1 : 0.5 }"
@@ -120,7 +121,7 @@ defineProps<{
 						({{ result.distribution ?? '—' }})
 					</button>
 					<select
-						v-if="result.frame"
+						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
 						v-model="result.distribution"
 						:disabled="!username"
 						@change="submit_annotation"
@@ -144,7 +145,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Subject type"
-						v-if="result.frame"
+						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.subject ? 1 : 0.5 }"
@@ -484,7 +485,7 @@ export default defineComponent({
 		},
 
 		guess_other_metadata(): void {
-			if (this.is_non_verb) {
+			if (this.is_non_verb || !this.result.pronominal_class) {
 				this.result.frame = undefined;
 				this.result.distribution = undefined;
 				this.result.subject = undefined;
@@ -513,10 +514,11 @@ export default defineComponent({
 				.replace(/[c012]/g, 'd')
 				.replace(/[ijk]/g, '');
 			this.result.subject ??= !this.result.frame.startsWith('c')
-				? 'predicate'
+				? 'proposition'
 				: this.result.pronominal_class === 'ta'
 				? 'free'
 				: 'individual';
+			if (this.result.pronominal_class) this.result.type ??= 'predicate';
 		},
 
 		submit_annotation(): void {
@@ -580,7 +582,7 @@ export default defineComponent({
 				fancy_content: shared.replacements(content, false, false, this.theme),
 			}));
 		},
-		any_editable_metadata(): boolean {
+		any_fixed_metadata(): boolean {
 			return !!(
 				this.result.pronominal_class ||
 				this.result.frame ||
@@ -596,6 +598,11 @@ export default defineComponent({
 		},
 		is_non_verb(): boolean {
 			return this.result.type && this.result.type !== 'predicate';
+		},
+		is_nullary_verb(): boolean {
+			return (
+				this.result.type === 'predicate' && !this.result.body?.includes('▯')
+			);
 		},
 		tangible(): boolean {
 			return (

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -562,7 +562,7 @@ export default defineComponent({
 				this.theme,
 			);
 			let type_and_gloss = this.result.type ? `${this.result.type}: ` : '';
-			type_and_gloss += this.result.gloss ? `'${this.result.gloss}'; ` : '';
+			type_and_gloss += this.result.gloss ? `‘${this.result.gloss}’; ` : '';
 			return type_and_gloss + body;
 		},
 		fancy_notes(): { user: string; fancy_content: string; date: string }[] {

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -41,6 +41,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Pronominal class"
+						v-if="!is_non_verb"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.pronominal_class ? 1 : 0.5 }"
@@ -175,20 +176,49 @@ defineProps<{
 				</div>
 			</div>
 		</div>
-		<textarea
+		<div
 			v-if="editing"
-			v-focus
-			class="body editing"
-			rows="1"
-			placeholder="Enter a definition using slots (example: _&hairsp;_&hairsp;_ likes _&hairsp;_&hairsp;_)"
-			@input="set_new_body"
-			:value.sync="new_body"
-			@keypress.enter.exact.prevent="submit_edit"
-			autocomplete="off"
-			autocorrect="on"
-			autocapitalize="on"
-			spellcheck="true"
-		></textarea>
+			style="
+				display: flex;
+				flex-direction: column;
+				gap: 0.5rem;
+				width: 100%;
+				margin-top: 0.5rem;
+			"
+		>
+			<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem">
+				<input
+					type="text"
+					placeholder="type"
+					v-model="new_type"
+					class="type editing"
+					@input="normalize_type"
+					@keypress.enter.exact.prevent="submit_edit"
+				/>
+				<input
+					type="text"
+					placeholder="gloss"
+					v-model="new_gloss"
+					class="gloss editing"
+					@input="normalize_gloss"
+					@keypress.enter.exact.prevent="submit_edit"
+				/>
+			</div>
+			<textarea
+				v-focus
+				class="body editing"
+				rows="1"
+				placeholder="Enter a definition using slots (example: _&hairsp;_&hairsp;_ likes _&hairsp;_&hairsp;_)"
+				@input="set_new_body"
+				:value.sync="new_body"
+				@keypress.enter.exact.prevent="submit_edit"
+				autocomplete="off"
+				autocorrect="on"
+				autocapitalize="on"
+				spellcheck="true"
+				style="width: 100%; margin: 0"
+			></textarea>
+		</div>
 		<p v-else class="body" v-html="fancy_body"></p>
 
 		<div class="meta-row">
@@ -410,6 +440,12 @@ export default defineComponent({
 			this.editing = true;
 			this.new_body = this.result.body;
 			this.new_scope = this.result.scope;
+			this.new_gloss = this.result.gloss;
+			this.new_type = this.result.type;
+			this.new_pronominal_class = this.result.pronominal_class;
+			this.new_frame = this.result.frame;
+			this.new_distribution = this.result.distribution;
+			this.new_subject = this.result.subject;
 		},
 
 		set_new_body(event: Event): void {
@@ -424,6 +460,19 @@ export default defineComponent({
 
 		submit_edit(): void {
 			this.$emit('edit', this.new_body, this.new_scope);
+			if (this.new_type === 'predicate') {
+				this.$emit(
+					'annotate',
+					this.new_gloss,
+					this.new_type,
+					this.new_pronominal_class,
+					this.new_frame,
+					this.new_distribution,
+					this.new_subject,
+				);
+			} else {
+				this.$emit('annotate', this.new_gloss, this.new_type, '', '', '', '');
+			}
 			this.editing = false;
 		},
 
@@ -500,6 +549,8 @@ export default defineComponent({
 			editing: false,
 			new_body: '',
 			new_scope: '',
+			new_type: '',
+			new_gloss: '',
 		};
 	},
 	computed: {

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -73,7 +73,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Frame"
-						v-if="any_metadata && !is_non_verb"
+						v-if="any_editable_metadata && !is_non_verb"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.frame ? 1 : 0.5 }"
@@ -82,7 +82,7 @@ defineProps<{
 					</button>
 					<select
 						title="Frame"
-						v-if="any_metadata && !is_non_verb"
+						v-if="any_editable_metadata && !is_non_verb"
 						v-model="result.frame"
 						:disabled="!username"
 						@change="submit_annotation"
@@ -437,6 +437,7 @@ export default defineComponent({
 				this.result.frame = undefined;
 				this.result.distribution = undefined;
 				this.result.subject = undefined;
+				this.result.pronominal_class = undefined;
 				return;
 			}
 			const definition =
@@ -470,6 +471,8 @@ export default defineComponent({
 		submit_annotation(): void {
 			this.$emit(
 				'annotate',
+				this.result.gloss,
+				this.result.type,
 				this.result.pronominal_class,
 				this.result.frame,
 				this.result.distribution,
@@ -506,7 +509,15 @@ export default defineComponent({
 	},
 	computed: {
 		fancy_body(): string {
-			return shared.replacements(this.result.body, false, false, this.theme);
+			let body = shared.replacements(
+				this.result.body,
+				false,
+				false,
+				this.theme,
+			);
+			let type_and_gloss = this.result.type ? `${this.result.type}: ` : '';
+			type_and_gloss += this.result.gloss ? `'${this.result.gloss}'; ` : '';
+			return type_and_gloss + body;
 		},
 		fancy_notes(): { user: string; fancy_content: string; date: string }[] {
 			const result = this.result as Entry;
@@ -516,7 +527,8 @@ export default defineComponent({
 				fancy_content: shared.replacements(content, false, false, this.theme),
 			}));
 		},
-		any_metadata(): boolean {
+		// TODO: make `type` and `gloss` editable
+		any_editable_metadata(): boolean {
 			return !!(
 				this.result.pronominal_class ||
 				this.result.frame ||
@@ -531,10 +543,7 @@ export default defineComponent({
 			return this.result.frame?.endsWith('c');
 		},
 		is_non_verb(): boolean {
-			return (
-				this.result.pronominal_class === 'particle' ||
-				this.result.pronominal_class === 'phrase'
-			);
+			return this.result.type !== 'predicate';
 		},
 		tangible(): boolean {
 			return (

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -46,10 +46,7 @@ defineProps<{
 						:style="{ opacity: result.pronominal_class ? 1 : 0.5 }"
 					>
 						{{
-							result.pronominal_class === 'particle' ||
-							result.pronominal_class === 'phrase'
-								? result.pronominal_class
-								: result.pronominal_class
+							result.pronominal_class
 								? result.pronominal_class.replace('a', 'á').replace('o', 'ó')
 								: '—'
 						}}
@@ -66,8 +63,6 @@ defineProps<{
 						<option value="maq">máq</option>
 						<option value="hoq">hóq</option>
 						<option value="ta">tá</option>
-						<option value="particle">particle</option>
-						<option value="phrase">phrase</option>
 					</select>
 				</div>
 				<div style="position: relative">

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -543,7 +543,7 @@ export default defineComponent({
 			return this.result.frame?.endsWith('c');
 		},
 		is_non_verb(): boolean {
-			return this.result.type !== 'predicate';
+			return this.result.type && this.result.type !== 'predicate';
 		},
 		tangible(): boolean {
 			return (

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -45,7 +45,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Pronominal class"
-						v-if="!is_non_verb && !is_nullary_verb"
+						v-if="!is_non_verb && has_slots"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.pronominal_class ? 1 : 0.5 }"
@@ -74,7 +74,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Frame"
-						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
+						v-if="any_fixed_metadata && !is_non_verb && has_slots"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.frame ? 1 : 0.5 }"
@@ -83,7 +83,7 @@ defineProps<{
 					</button>
 					<select
 						title="Frame"
-						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
+						v-if="any_fixed_metadata && !is_non_verb && has_slots"
 						v-model="result.frame"
 						:disabled="!username"
 						@change="submit_annotation"
@@ -113,7 +113,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Distribution"
-						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
+						v-if="any_fixed_metadata && !is_non_verb && has_slots"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.distribution ? 1 : 0.5 }"
@@ -121,7 +121,7 @@ defineProps<{
 						({{ result.distribution ?? '—' }})
 					</button>
 					<select
-						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
+						v-if="any_fixed_metadata && !is_non_verb && has_slots"
 						v-model="result.distribution"
 						:disabled="!username"
 						@change="submit_annotation"
@@ -145,7 +145,7 @@ defineProps<{
 				<div style="position: relative">
 					<button
 						title="Subject type"
-						v-if="any_fixed_metadata && !is_non_verb && !is_nullary_verb"
+						v-if="any_fixed_metadata && !is_non_verb && has_slots"
 						:disabled="!username"
 						@click.prevent="username && show_picker($event)"
 						:style="{ opacity: result.subject ? 1 : 0.5 }"
@@ -610,10 +610,8 @@ export default defineComponent({
 		is_non_verb(): boolean {
 			return this.result.type && this.result.type !== 'predicate';
 		},
-		is_nullary_verb(): boolean {
-			return (
-				this.result.type === 'predicate' && !this.result.body?.includes('▯')
-			);
+		has_slots(): boolean {
+			return this.result.body?.includes('▯');
 		},
 		tangible(): boolean {
 			return (

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -192,7 +192,6 @@ defineProps<{
 					placeholder="type"
 					v-model="new_type"
 					class="type editing"
-					@input="normalize_type"
 					@keypress.enter.exact.prevent="submit_edit"
 				/>
 				<input
@@ -200,7 +199,6 @@ defineProps<{
 					placeholder="gloss"
 					v-model="new_gloss"
 					class="gloss editing"
-					@input="normalize_gloss"
 					@keypress.enter.exact.prevent="submit_edit"
 				/>
 			</div>

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -223,7 +223,12 @@ defineProps<{
 				spellcheck="true"
 				style="width: 100%; margin: 0"
 			></textarea>
-			<p v-else class="body" v-html="fancy_body" style="margin: 0"></p>
+			<p
+				v-else
+				class="body"
+				v-html="shared.replacements(new_body, false, false, theme)"
+				style="margin: 0"
+			></p>
 		</div>
 		<p v-else class="body" v-html="fancy_body"></p>
 
@@ -391,6 +396,8 @@ import * as shared from './shared/index';
 
 export default defineComponent({
 	methods: {
+		shared: () => shared,
+
 		score_color(score: number): string {
 			return shared.score_color(score, this.theme).css;
 		},

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -526,7 +526,7 @@ export default defineComponent({
 			this.result.subject = this.result.subject
 				? this.result.subject
 				: !this.result.frame.startsWith('c')
-				? 'proposition'
+				? 'predicate'
 				: this.result.pronominal_class === 'ta'
 				? 'free'
 				: 'individual';

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -475,7 +475,7 @@ export default defineComponent({
 			if (this.username === this.result.user) {
 				this.$emit('edit', this.new_body, this.new_scope);
 			}
-			if (this.new_type === 'predicate') {
+			if (this.new_type === 'predicate' || !this.new_type) {
 				this.$emit(
 					'annotate',
 					this.new_gloss,
@@ -499,33 +499,37 @@ export default defineComponent({
 				this.result.pronominal_class = undefined;
 				return;
 			}
+			this.result.type = this.result.type ? this.result.type : 'predicate';
 			const definition =
 				this.result.body
 					.toLowerCase()
 					.split(';')
 					.find(x => x.includes('▯')) ?? '';
-			this.result.frame ??= [
-				...definition
-					.replace(/\d/g, '')
-					.replace(/▯ (\S+ ){0,2}the case/g, '0')
-					.replace(/satisf\w+ (property )?▯/g, '1')
-					.replace(/property ▯/g, '1')
-					.replace(/relation ▯/g, '2')
-					.replace(/[^012▯]/g, '')
-					.replace(/▯/g, 'c'),
-			]
-				.join(' ')
-				.replace(/1/g, '1i')
-				.replace(/2/g, '2ij');
-			this.result.distribution ??= this.result.frame
-				.replace(/[c012]/g, 'd')
-				.replace(/[ijk]/g, '');
-			this.result.subject ??= !this.result.frame.startsWith('c')
+			this.result.frame = this.result.frame
+				? this.result.frame
+				: [
+						...definition
+							.replace(/\d/g, '')
+							.replace(/▯ (\S+ ){0,2}the case/g, '0')
+							.replace(/satisf\w+ (property )?▯/g, '1')
+							.replace(/property ▯/g, '1')
+							.replace(/relation ▯/g, '2')
+							.replace(/[^012▯]/g, '')
+							.replace(/▯/g, 'c'),
+				  ]
+						.join(' ')
+						.replace(/1/g, '1i')
+						.replace(/2/g, '2ij');
+			this.result.distribution = this.result.distribution
+				? this.result.distribution
+				: this.result.frame.replace(/[c012]/g, 'd').replace(/[ijk]/g, '');
+			this.result.subject = this.result.subject
+				? this.result.subject
+				: !this.result.frame.startsWith('c')
 				? 'proposition'
 				: this.result.pronominal_class === 'ta'
 				? 'free'
 				: 'individual';
-			if (this.result.pronominal_class) this.result.type ??= 'predicate';
 		},
 
 		submit_annotation(): void {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "toadua-frontend",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "A collaborative dictionary for the Toaq language.",
 	"main": "./frontend.ts",
 	"type": "module",

--- a/frontend/shared/index.ts
+++ b/frontend/shared/index.ts
@@ -213,6 +213,8 @@ export function parse_query(query_string: string): {
 						parts[0],
 						['arity', 'myvote'].includes(parts[0])
 							? parseInt(parts[1], 10) || 0
+							: ['complete'].includes(parts[0])
+							? parts[1] === 'true'
 							: parts[1],
 					];
 			} else {

--- a/modules/housekeep.test.ts
+++ b/modules/housekeep.test.ts
@@ -179,6 +179,14 @@ describe('HousekeepModule', () => {
 					scope: 'en',
 					date: '2024-01-02T00:00:00.000Z',
 				}),
+				makeEntry({
+					head: 'bao',
+					gloss: 'white',
+					body: '___ is white',
+					user: 'alice',
+					scope: 'en',
+					date: '2024-01-02T00:00:00.000Z',
+				}),
 			];
 			housekeep.up(store, makeConfig());
 			expect(store.db.entries).toEqual([
@@ -192,6 +200,15 @@ describe('HousekeepModule', () => {
 				}),
 				makeEntry({
 					head: 'bao',
+					body: '▯ is white',
+					type: 'predicate',
+					user: 'alice',
+					scope: 'en',
+					date: '2024-01-02T00:00:00.000Z',
+				}),
+				makeEntry({
+					head: 'bao',
+					gloss: 'white',
 					body: '▯ is white',
 					type: 'predicate',
 					user: 'alice',

--- a/modules/housekeep.test.ts
+++ b/modules/housekeep.test.ts
@@ -79,6 +79,37 @@ describe('HousekeepModule', () => {
 		});
 	});
 
+	describe('type and gloss relocation', () => {
+		test('relocates type and gloss from body to dedicated fields', () => {
+			store.db.entries = [
+				makeEntry({ head: 'katolıq', body: '▯ is a catgirl', scope: 'en' }),
+				makeEntry({ head: 'ꝡeꝡa', body: 'predicate: ▯ is ꝡeꝡa', scope: 'en' }),
+				makeEntry({
+					head: 'súq',
+					body: "pronoun: '2S'; second-person singular",
+					scope: 'en',
+				}),
+			];
+			housekeep.up(store, makeConfig());
+			expect(store.db.entries).toEqual([
+				makeEntry({ head: 'katolıq', body: '▯ is a catgirl', scope: 'en' }),
+				makeEntry({
+					head: 'ꝡeꝡa',
+					body: '▯ is ꝡeꝡa',
+					scope: 'en',
+					type: 'predicate',
+				}),
+				makeEntry({
+					head: 'súq',
+					body: 'second-person singular',
+					scope: 'en',
+					type: 'pronoun',
+					gloss: '2S',
+				}),
+			]);
+		});
+	});
+
 	describe('duplicate entry removal', () => {
 		test('removes duplicate entries', () => {
 			store.db.entries = [

--- a/modules/housekeep.test.ts
+++ b/modules/housekeep.test.ts
@@ -19,6 +19,8 @@ const makeEntry = (overrides: Partial<commons.Entry> = {}): commons.Entry => ({
 	frame: undefined,
 	distribution: undefined,
 	subject: undefined,
+	gloss: undefined,
+	type: undefined,
 	...overrides,
 });
 

--- a/modules/housekeep.test.ts
+++ b/modules/housekeep.test.ts
@@ -73,8 +73,18 @@ describe('HousekeepModule', () => {
 			];
 			housekeep.up(store, makeConfig());
 			expect(store.db.entries).toEqual([
-				makeEntry({ head: 'ꝡeꝡa', body: '▯ is veva', scope: 'en' }),
-				makeEntry({ head: 'katolıq', body: 'gırı ▯', scope: 'toa' }),
+				makeEntry({
+					head: 'ꝡeꝡa',
+					body: '▯ is veva',
+					scope: 'en',
+					type: 'predicate',
+				}),
+				makeEntry({
+					head: 'katolıq',
+					body: 'gırı ▯',
+					scope: 'toa',
+					type: 'predicate',
+				}),
 			]);
 		});
 	});
@@ -89,10 +99,27 @@ describe('HousekeepModule', () => {
 					body: "pronoun: '2S'; second-person singular",
 					scope: 'en',
 				}),
+				makeEntry({ head: 'ku-', body: 'non-contrastive focus', scope: 'en' }),
+				makeEntry({
+					head: '- go',
+					body: 'object of passive function',
+					scope: 'en',
+				}),
+				makeEntry({
+					head: '- go',
+					body: 'object of passive function',
+					scope: 'en',
+					type: 'suffix',
+				}),
 			];
 			housekeep.up(store, makeConfig());
 			expect(store.db.entries).toEqual([
-				makeEntry({ head: 'katolıq', body: '▯ is a catgirl', scope: 'en' }),
+				makeEntry({
+					head: 'katolıq',
+					body: '▯ is a catgirl',
+					scope: 'en',
+					type: 'predicate',
+				}),
 				makeEntry({
 					head: 'ꝡeꝡa',
 					body: '▯ is ꝡeꝡa',
@@ -105,6 +132,24 @@ describe('HousekeepModule', () => {
 					scope: 'en',
 					type: 'pronoun',
 					gloss: '2S',
+				}),
+				makeEntry({
+					head: 'ku-',
+					body: 'non-contrastive focus',
+					scope: 'en',
+					type: 'prefix',
+				}),
+				makeEntry({
+					head: '- go',
+					body: 'object of passive function',
+					scope: 'en',
+					type: 'pseudo-suffix',
+				}),
+				makeEntry({
+					head: '- go',
+					body: 'object of passive function',
+					scope: 'en',
+					type: 'suffix',
 				}),
 			]);
 		});
@@ -140,6 +185,7 @@ describe('HousekeepModule', () => {
 				makeEntry({
 					head: 'bao',
 					body: '▯ is off-white',
+					type: 'predicate',
 					user: 'bob',
 					scope: 'en',
 					date: '2024-01-01T00:00:00.000Z',
@@ -147,6 +193,7 @@ describe('HousekeepModule', () => {
 				makeEntry({
 					head: 'bao',
 					body: '▯ is white',
+					type: 'predicate',
 					user: 'alice',
 					scope: 'en',
 					date: '2024-01-02T00:00:00.000Z',

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -75,7 +75,7 @@ export class HousekeepModule {
 		let extracted_type = 0;
 		let extracted_gloss = 0;
 
-		const type_pattern = /^(\w+): /;
+		const type_pattern = /^([ \-\w]+): /;
 		const gloss_pattern = /^'((\w\.)*\w+)'; /;
 
 		for (const entry of store.db.entries) {

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -76,7 +76,7 @@ export class HousekeepModule {
 		let extracted_gloss = 0;
 
 		const type_pattern = /^\s*([ \-a-zA-Z0-9]{1,30}):/;
-		const gloss_pattern = /^\s*'(([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)';/;
+		const gloss_pattern = /^\s*['‘](([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)['’];/;
 
 		for (const entry of store.db.entries) {
 			let rest = entry.body;

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -91,6 +91,16 @@ export class HousekeepModule {
 				}
 			}
 
+			if (entry.pronominal_class === 'phrase') {
+				entry.type = entry.type ?? 'phrase';
+				entry.pronominal_class = undefined;
+				extracted_type++;
+			}
+
+			if (entry.pronominal_class === 'particle') {
+				entry.pronominal_class = undefined;
+			}
+
 			if (entry.gloss === undefined && entry.type !== 'phrase') {
 				const gloss_match = gloss_pattern.exec(rest);
 				if (gloss_match) {
@@ -101,16 +111,6 @@ export class HousekeepModule {
 			}
 
 			entry.body = rest.trim();
-
-			if (entry.pronominal_class === 'phrase') {
-				entry.type = entry.type ?? 'phrase';
-				entry.pronominal_class = undefined;
-				extracted_type++;
-			}
-
-			if (entry.pronominal_class === 'particle') {
-				entry.pronominal_class = undefined;
-			}
 		}
 
 		if (extracted_type !== 0) {

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -76,7 +76,8 @@ export class HousekeepModule {
 		let extracted_gloss = 0;
 
 		const type_pattern = /^\s*([ \-a-zA-Z0-9]+):/;
-		const gloss_pattern = /^\s*[“'‘](([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)[”'’];/;
+		const gloss_pattern =
+			/^\s*[“'‘"](([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)[”'’"];/;
 
 		for (const entry of store.db.entries) {
 			let rest = entry.body;

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -81,18 +81,22 @@ export class HousekeepModule {
 		for (const entry of store.db.entries) {
 			let rest = entry.body;
 
-			const type_match = type_pattern.exec(rest);
-			if (type_match) {
-				entry.type = type_match[1];
-				rest = rest.slice(type_match[0].length);
-				extracted_type++;
+			if (entry.type === undefined) {
+				const type_match = type_pattern.exec(rest);
+				if (type_match) {
+					entry.type = type_match[1];
+					rest = rest.slice(type_match[0].length);
+					extracted_type++;
+				}
 			}
 
-			const gloss_match = gloss_pattern.exec(rest);
-			if (gloss_match) {
-				entry.gloss = gloss_match[1];
-				rest = rest.slice(gloss_match[0].length);
-				extracted_gloss++;
+			if (entry.gloss === undefined) {
+				const gloss_match = gloss_pattern.exec(rest);
+				if (gloss_match) {
+					entry.gloss = gloss_match[1];
+					rest = rest.slice(gloss_match[0].length);
+					extracted_gloss++;
+				}
 			}
 
 			entry.body = rest;

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -16,6 +16,7 @@ export class HousekeepModule {
 		this.reform_entries(store);
 		this.remove_duplicates(store);
 		this.remove_bad_entries(store);
+		this.relocate_type_and_gloss(store);
 
 		this.search.recache();
 	}
@@ -68,6 +69,42 @@ export class HousekeepModule {
 			if (didReform) reformed++;
 		}
 		if (reformed) console.log(`reformed ${reformed} entries`);
+	}
+
+	private relocate_type_and_gloss(store: commons.Store) {
+		let extracted_type = 0;
+		let extracted_gloss = 0;
+
+		const type_pattern = /^(\w+): /;
+		const gloss_pattern = /^'((\w\.)*\w+)'; /;
+
+		for (const entry of store.db.entries) {
+			let rest = entry.body;
+
+			const type_match = type_pattern.exec(rest);
+			if (type_match) {
+				entry.type = type_match[1];
+				rest = rest.slice(type_match[0].length);
+				extracted_type++;
+			}
+
+			const gloss_match = gloss_pattern.exec(rest);
+			if (gloss_match) {
+				entry.gloss = gloss_match[1];
+				rest = rest.slice(gloss_match[0].length);
+				extracted_gloss++;
+			}
+
+			entry.body = rest;
+		}
+
+		if (extracted_type !== 0) {
+			console.log(`moved ${extracted_type} type annotations out of bodies`);
+		}
+
+		if (extracted_gloss !== 0) {
+			console.log(`moved ${extracted_gloss} gloss annotations out of bodies`);
+		}
 	}
 
 	private remove_duplicates(store: commons.Store) {

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -2,7 +2,7 @@
 // tamper with the database store
 
 import type * as commons from '../core/commons.js';
-import type { Token } from '../core/commons.js';
+import { tryAssessType, type Token } from '../core/commons.js';
 import { Search } from '../core/search.js';
 import * as shared from '../frontend/shared/index.js';
 
@@ -85,20 +85,28 @@ export class HousekeepModule {
 			if (entry.type === undefined) {
 				const type_match = type_pattern.exec(rest);
 				if (type_match) {
-					entry.type = type_match[1];
+					entry.type = type_match[1][0].toLowerCase() + type_match[1].slice(1);
 					rest = rest.slice(type_match[0].length);
 					extracted_type++;
+				} else {
+					entry.type = tryAssessType(entry);
+					if (entry.type) extracted_type++;
 				}
 			}
 
 			if (entry.pronominal_class === 'phrase') {
-				entry.type = entry.type ?? 'phrase';
 				entry.pronominal_class = undefined;
-				extracted_type++;
+				if (!entry.type) {
+					entry.type = 'phrase';
+					extracted_type++;
+				}
 			}
 
 			if (entry.pronominal_class === 'particle') {
 				entry.pronominal_class = undefined;
+				entry.frame = undefined;
+				entry.distribution = undefined;
+				entry.subject = undefined;
 			}
 
 			if (entry.gloss === undefined && entry.type !== 'phrase') {
@@ -127,7 +135,7 @@ export class HousekeepModule {
 	private remove_duplicates(store: commons.Store) {
 		const newest_version = new Map<string, commons.Entry>();
 		for (const e of store.db.entries) {
-			const key = `${e.user}\0${e.head}\0${e.body}\0${e.scope}`;
+			const key = `${e.user}\0${e.head}\0${e.gloss}\0${e.body}\0${e.type}\0${e.pronominal_class}\0${e.frame}\0${e.distribution}\0${e.subject}\0${e.scope}`;
 			const other = newest_version.get(key);
 			if (other && other.date >= e.date) {
 				e.scope = '';

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -75,8 +75,8 @@ export class HousekeepModule {
 		let extracted_type = 0;
 		let extracted_gloss = 0;
 
-		const type_pattern = /^([ \-a-zA-Z0-9]{1,30}):/;
-		const gloss_pattern = /^'(([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)';/;
+		const type_pattern = /^\s*([ \-a-zA-Z0-9]{1,30}):/;
+		const gloss_pattern = /^\s*'(([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)';/;
 
 		for (const entry of store.db.entries) {
 			let rest = entry.body;

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -75,8 +75,8 @@ export class HousekeepModule {
 		let extracted_type = 0;
 		let extracted_gloss = 0;
 
-		const type_pattern = /^([ \-\w]+): /;
-		const gloss_pattern = /^'((\w\.)*\w+)'; /;
+		const type_pattern = /^([ \-a-zA-Z0-9]{1,30}):/;
+		const gloss_pattern = /^'(([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)';/;
 
 		for (const entry of store.db.entries) {
 			let rest = entry.body;
@@ -99,7 +99,7 @@ export class HousekeepModule {
 				}
 			}
 
-			entry.body = rest;
+			entry.body = rest.trim();
 		}
 
 		if (extracted_type !== 0) {

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -79,6 +79,16 @@ export class HousekeepModule {
 		const gloss_pattern = /^\s*['‘](([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)['’];/;
 
 		for (const entry of store.db.entries) {
+			if (entry.pronominal_class === 'phrase') {
+				entry.type = 'phrase';
+				entry.pronominal_class = undefined;
+				extracted_type++;
+			}
+
+			if (entry.pronominal_class === 'particle') {
+				entry.pronominal_class = undefined;
+			}
+
 			let rest = entry.body;
 
 			if (entry.type === undefined) {
@@ -103,7 +113,9 @@ export class HousekeepModule {
 		}
 
 		if (extracted_type !== 0) {
-			console.log(`moved ${extracted_type} type annotations out of bodies`);
+			console.log(
+				`moved ${extracted_type} type annotations out of other fields`,
+			);
 		}
 
 		if (extracted_gloss !== 0) {

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -75,20 +75,10 @@ export class HousekeepModule {
 		let extracted_type = 0;
 		let extracted_gloss = 0;
 
-		const type_pattern = /^\s*([ \-a-zA-Z0-9]{1,30}):/;
-		const gloss_pattern = /^\s*['‘](([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)['’];/;
+		const type_pattern = /^\s*([ \-a-zA-Z0-9]+):/;
+		const gloss_pattern = /^\s*[“'‘](([\-a-zA-Z0-9]+\.)*[\-a-zA-Z0-9]+)[”'’];/;
 
 		for (const entry of store.db.entries) {
-			if (entry.pronominal_class === 'phrase') {
-				entry.type = 'phrase';
-				entry.pronominal_class = undefined;
-				extracted_type++;
-			}
-
-			if (entry.pronominal_class === 'particle') {
-				entry.pronominal_class = undefined;
-			}
-
 			let rest = entry.body;
 
 			if (entry.type === undefined) {
@@ -100,7 +90,7 @@ export class HousekeepModule {
 				}
 			}
 
-			if (entry.gloss === undefined) {
+			if (entry.gloss === undefined && entry.type !== 'phrase') {
 				const gloss_match = gloss_pattern.exec(rest);
 				if (gloss_match) {
 					entry.gloss = gloss_match[1];
@@ -110,6 +100,16 @@ export class HousekeepModule {
 			}
 
 			entry.body = rest.trim();
+
+			if (entry.pronominal_class === 'phrase') {
+				entry.type = entry.type ?? 'phrase';
+				entry.pronominal_class = undefined;
+				extracted_type++;
+			}
+
+			if (entry.pronominal_class === 'particle') {
+				entry.pronominal_class = undefined;
+			}
 		}
 
 		if (extracted_type !== 0) {

--- a/modules/update.test.ts
+++ b/modules/update.test.ts
@@ -157,7 +157,7 @@ describe('UpdateModule', () => {
 							{
 								head: '%(word)',
 								gloss: '%(gloss)',
-								body: 'verb: %(definition)',
+								body: '%(definition)',
 								type: '%(type)',
 								frame: 'testy %(frame)',
 								pronominal_class: '%(pronominal_class)',
@@ -186,7 +186,7 @@ describe('UpdateModule', () => {
 					expect.objectContaining({
 						head: 'word1',
 						gloss: 'gloss1',
-						body: 'verb: definition for word1',
+						body: 'definition for word1',
 						scope: 'en',
 						type: 'type1',
 						frame: 'testy frame1',
@@ -199,7 +199,7 @@ describe('UpdateModule', () => {
 					expect.objectContaining({
 						head: 'word2',
 						gloss: 'gloss2',
-						body: 'verb: definition for word2',
+						body: 'definition for word2',
 						scope: 'en',
 						type: 'type2',
 						frame: 'testy frame2',
@@ -212,7 +212,7 @@ describe('UpdateModule', () => {
 					expect.objectContaining({
 						head: 'word3',
 						gloss: undefined,
-						body: 'verb: definition for word3',
+						body: 'definition for word3',
 						scope: 'en',
 						type: undefined,
 						frame: undefined,

--- a/modules/update.test.ts
+++ b/modules/update.test.ts
@@ -124,7 +124,9 @@ describe('UpdateModule', () => {
 				const jsonData = JSON.stringify([
 					{
 						word: 'Word1',
+						gloss: 'gloss1',
 						definition: 'definition for word1',
+						type: 'type1',
 						frame: 'frame1',
 						pronominal_class: 'class1',
 						subject: 'subj1',
@@ -132,7 +134,9 @@ describe('UpdateModule', () => {
 					},
 					{
 						word: 'Word2',
+						gloss: 'gloss2',
 						definition: 'definition for word2',
+						type: 'type2',
 						frame: 'frame2',
 						pronominal_class: 'class2',
 						subject: 'subj2',
@@ -152,7 +156,9 @@ describe('UpdateModule', () => {
 						patterns: [
 							{
 								head: '%(word)',
+								gloss: '%(gloss)',
 								body: 'verb: %(definition)',
+								type: '%(type)',
 								frame: 'testy %(frame)',
 								pronominal_class: '%(pronominal_class)',
 								subject: '%(subject)',
@@ -179,8 +185,10 @@ describe('UpdateModule', () => {
 				expect(mockStore.db.entries[0]).toEqual(
 					expect.objectContaining({
 						head: 'word1',
+						gloss: 'gloss1',
 						body: 'verb: definition for word1',
 						scope: 'en',
+						type: 'type1',
 						frame: 'testy frame1',
 						pronominal_class: 'class1',
 						subject: 'subj1',
@@ -190,8 +198,10 @@ describe('UpdateModule', () => {
 				expect(mockStore.db.entries[1]).toEqual(
 					expect.objectContaining({
 						head: 'word2',
+						gloss: 'gloss2',
 						body: 'verb: definition for word2',
 						scope: 'en',
+						type: 'type2',
 						frame: 'testy frame2',
 						pronominal_class: 'class2',
 						subject: 'subj2',
@@ -201,8 +211,10 @@ describe('UpdateModule', () => {
 				expect(mockStore.db.entries[2]).toEqual(
 					expect.objectContaining({
 						head: 'word3',
+						gloss: undefined,
 						body: 'verb: definition for word3',
 						scope: 'en',
+						type: undefined,
 						frame: undefined,
 						pronominal_class: undefined,
 						subject: undefined,
@@ -246,7 +258,7 @@ describe('UpdateModule', () => {
 					id: 'off0',
 					date: '2023-01-01T00:00:00.000Z',
 					head: 'choa',
-					body: 'verb: ‘speak’; to speak',
+					body: 'to speak',
 					user: 'official',
 					scope: 'en',
 					notes: [],
@@ -256,11 +268,11 @@ describe('UpdateModule', () => {
 					frame: 'c 1',
 					distribution: 'd',
 					subject: 'agent',
-					gloss: 'utter',
-					type: 'predicate'
+					gloss: 'speak',
+					type: 'verb',
 				},
 				{
-					...stale('off2', 'official', 'geo', 'verb: ‘old’; to be old'),
+					...stale('off2', 'official', 'geo', 'to be old'),
 					notes: [
 						{
 							date: '2024-06-01T00:00:00.000Z',
@@ -269,7 +281,7 @@ describe('UpdateModule', () => {
 						},
 					],
 				},
-				stale('off3', 'official', 'gone', 'verb: ‘gone’; to no longer exist'),
+				stale('off3', 'official', 'gone', 'to no longer exist'),
 				stale('ex1', 'examples', 'phrase1', 'old body 1'),
 				stale('ex2', 'examples', 'phrase2', 'old body 2'),
 			);
@@ -320,7 +332,9 @@ describe('UpdateModule', () => {
 					patterns: [
 						{
 							head: '%(toaq)',
-							body: '%(type): ‘%(gloss)’; %(english)',
+							gloss: '%(gloss)',
+							body: '%(english)',
+							type: '%(type)',
 							frame: '%(frame)',
 							pronominal_class: '%(pronominal_class)',
 							subject: '%(subject)',
@@ -367,7 +381,9 @@ describe('UpdateModule', () => {
 					expect.objectContaining({
 						user: 'official',
 						head: 'choa',
-						body: 'verb: ‘speak’; to speak',
+						gloss: 'speak',
+						body: 'to speak',
+						type: 'verb',
 						pronominal_class: 'ta',
 						frame: 'c 1',
 						distribution: 'd',
@@ -376,7 +392,9 @@ describe('UpdateModule', () => {
 					expect.objectContaining({
 						user: 'official',
 						head: 'geo',
-						body: 'verb: ‘old’; to be old',
+						gloss: 'old',
+						body: 'to be old',
+						type: 'verb',
 						pronominal_class: 'ta',
 						frame: 'c',
 						distribution: 'd',

--- a/modules/update.test.ts
+++ b/modules/update.test.ts
@@ -234,6 +234,8 @@ describe('UpdateModule', () => {
 				frame: undefined,
 				distribution: undefined,
 				subject: undefined,
+				gloss: undefined,
+				type: undefined,
 			});
 
 			mockStore.db.entries.push(
@@ -254,6 +256,8 @@ describe('UpdateModule', () => {
 					frame: 'c 1',
 					distribution: 'd',
 					subject: 'agent',
+					gloss: 'utter',
+					type: 'predicate'
 				},
 				{
 					...stale('off2', 'official', 'geo', 'verb: ‘old’; to be old'),

--- a/modules/update.ts
+++ b/modules/update.ts
@@ -171,7 +171,7 @@ export class UpdateModule {
 					entry =>
 						entry.$.scope === 'en' &&
 						entry.$.head === head &&
-						entry.$.gloss === gloss && // this is the first thing to break the tests (expected 4 entries; got 5)
+						entry.$.gloss === gloss &&
 						entry.$.body === body &&
 						entry.$.type === type &&
 						entry.$.frame === frame &&
@@ -224,22 +224,14 @@ export class UpdateModule {
 				fetched.set(uname, merged);
 			}
 
-			// console.log(fetched);
-
 			const to_delete: Set<string> = new Set();
 			for (let e of store.db.entries) {
 				if (!unames.has(e.user)) continue;
 				const found = fetched.get(e.user)?.get(e.head);
 
-				if (found) {
-					console.log('\n' + e.head + ':  ');
-					console.log(found.gloss, e.gloss, found.gloss == e.gloss);
-					console.log(found.type, e.type, found.type == e.type);
-				}
-
 				if (
 					found &&
-					found.gloss === e.gloss && // this is the second thing: expect "official"; got undefined
+					found.gloss === e.gloss &&
 					found.body === e.body &&
 					found.type === e.type &&
 					found.frame === e.frame &&
@@ -249,8 +241,6 @@ export class UpdateModule {
 				) {
 					continue;
 				}
-
-				// console.log(found);
 
 				const originalUser = e.user;
 				console.log(`~~ '${e.head}' obsoleted`);

--- a/modules/update.ts
+++ b/modules/update.ts
@@ -8,6 +8,7 @@ import * as announce from './announce.js';
 import * as shared from '../frontend/shared/index.js';
 
 import request from 'request-promise-native';
+import { head } from 'request';
 
 export interface SourceConfig {
 	/**
@@ -80,7 +81,9 @@ const FORMATS: Record<string, UpdateFormat> = {
 type WordList = Map<
 	string,
 	{
+		gloss?: string;
 		body: string;
+		type?: string;
 		frame?: string;
 		pronominal_class?: string;
 		subject?: string;
@@ -118,7 +121,15 @@ export class UpdateModule {
 						for (const entry of FORMATS[format](data as string, rest)) {
 							if (!entry.head || !entry.body) continue;
 							word_list.set(shared.normalize(entry.head), {
+								gloss:
+									entry.gloss !== undefined
+										? entry.gloss.normalize('NFC')
+										: undefined,
 								body: replacements(entry.body),
+								type:
+									entry.type !== undefined
+										? entry.type.normalize('NFC')
+										: undefined,
 								frame: entry.frame,
 								pronominal_class: entry.pronominal_class,
 								subject: entry.subject,
@@ -154,13 +165,15 @@ export class UpdateModule {
 			const user = cf[name].user;
 			for (const [
 				head,
-				{ body, frame, pronominal_class, subject, distribution },
+				{ gloss, body, type, frame, pronominal_class, subject, distribution },
 			] of word_list.entries()) {
 				const exists = this.search.some(
 					entry =>
 						entry.$.scope === 'en' &&
 						entry.$.head === head &&
+						entry.$.gloss === gloss && // this is the first thing to break the tests (expected 4 entries; got 5)
 						entry.$.body === body &&
+						entry.$.type === type &&
 						entry.$.frame === frame &&
 						entry.$.pronominal_class === pronominal_class &&
 						entry.$.subject === subject &&
@@ -170,9 +183,11 @@ export class UpdateModule {
 					const res = await this.api.call(
 						{
 							action: 'create',
-							head,
-							body,
 							scope: 'en',
+							head,
+							gloss,
+							body,
+							type,
 							frame,
 							pronominal_class,
 							subject,
@@ -209,19 +224,34 @@ export class UpdateModule {
 				fetched.set(uname, merged);
 			}
 
+			// console.log(fetched);
+
 			const to_delete: Set<string> = new Set();
 			for (let e of store.db.entries) {
 				if (!unames.has(e.user)) continue;
 				const found = fetched.get(e.user)?.get(e.head);
+
+				if (found) {
+					console.log('\n' + e.head + ':  ');
+					console.log(found.gloss, e.gloss, found.gloss == e.gloss);
+					console.log(found.type, e.type, found.type == e.type);
+				}
+
 				if (
 					found &&
+					found.gloss === e.gloss && // this is the second thing: expect "official"; got undefined
 					found.body === e.body &&
+					found.type === e.type &&
 					found.frame === e.frame &&
 					found.pronominal_class === e.pronominal_class &&
 					found.subject === e.subject &&
 					found.distribution === e.distribution
-				)
+				) {
 					continue;
+				}
+
+				// console.log(found);
+
 				const originalUser = e.user;
 				console.log(`~~ '${e.head}' obsoleted`);
 				messages[originalUser] ||= [];

--- a/modules/update.ts
+++ b/modules/update.ts
@@ -8,7 +8,6 @@ import * as announce from './announce.js';
 import * as shared from '../frontend/shared/index.js';
 
 import request from 'request-promise-native';
-import { head } from 'request';
 
 export interface SourceConfig {
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "toadua",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "A collaborative dictionary for the Toaq language.",
 	"main": "core/server.js",
 	"type": "module",


### PR DESCRIPTION
This adds `type` and `gloss` fields to the back-end, separating that data from `body` (e.g. when ingesting from toaq/dictionary), and modifies the front-end to use the new fields in displaying and editing results.

Anyhow, marking this as draft, because I'd like some more eyes (and time testing).