### PR TITLE
replace subject "predicate" with "proposition" (aligns with official)

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -67,7 +67,7 @@ export const SUBJECTS = [
 	'agent',
 	'individual',
 	'event',
-	'predicate',
+	'proposition',
 	'shape',
 	'free',
 ];

--- a/core/commons.ts
+++ b/core/commons.ts
@@ -154,7 +154,7 @@ export interface CommonEntry {
 	frame: string | undefined;
 	/// The distribution of the entry, e.g. `"d"`, `"n"`, `"d d"`.
 	distribution: string | undefined;
-	/// The subject of the entry: `"agent"`, `"individual"`, `"event"`, `"predicate"`, `"shape"`, or `"free"`.
+	/// The subject of the entry: `"agent"`, `"individual"`, `"event"`, `"proposition"`, `"shape"`, or `"free"`.
 	subject: string | undefined;
 }
 

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -175,7 +175,7 @@ defineProps<{
 						<option :disabled="tangible" value="event">sE</option>
 						<option value="" disabled>Subject is an event</option>
 						<hr />
-						<option :disabled="tangible" value="predicate">sP</option>
+						<option :disabled="tangible" value="proposition">sP</option>
 						<option value="" disabled>Subject is a proposition</option>
 						<hr />
 						<option :disabled="tangible" value="shape">sS</option>
@@ -534,7 +534,7 @@ export default defineComponent({
 			this.result.subject = this.result.subject
 				? this.result.subject
 				: !this.result.frame.startsWith('c')
-				? 'predicate'
+				? 'proposition'
 				: this.result.pronominal_class === 'ta'
 				? 'free'
 				: 'individual';

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -51,6 +51,11 @@ export class HousekeepModule {
 				}
 			}
 
+			if (entry.subject === 'predicate') {
+				entry.subject = 'proposition';
+				didReform = true;
+			}
+
 			const placeholderRegex = /___|◌(?!\p{Diacritic})/gu;
 			const normalizedBody = entry.body.replace(placeholderRegex, '▯');
 			if (normalizedBody !== entry.body) {


### PR DESCRIPTION
* adds code to fix entries with "predicate" in the subject field (housekeep `reform_entries`)
* replaces "predicate" with "proposition" in relevant places