### PR TITLE
Patch semantics for the `annotate` API function and more uniform data representation.

### DIFF
--- a/core/api.ts
+++ b/core/api.ts
@@ -288,7 +288,7 @@ export class Api {
 		// check that each of the disjoint-union metadata fields has a valid value
 		for (var field of FIXED_ANNOTATION_FIELDS) {
 			if (
-				i[field] != null &&
+				i[field] &&
 				!FIXED_ANNOTATION_FIELD_OPTIONS[field].includes(i[field])
 			) {
 				return flip(`invalid field '${field}': ${i[field]}`);
@@ -298,12 +298,11 @@ export class Api {
 		const word = this.by_id(i.id);
 		if (!word) return flip('no such word');
 
-		word.pronominal_class = i.pronominal_class;
-		word.frame = i.frame;
-		word.distribution = i.distribution;
-		word.subject = i.subject;
-		word.gloss = i.gloss;
-		word.type = i.type;
+		const updated_fields = FIXED_ANNOTATION_FIELDS.concat([
+			'gloss',
+			'type',
+		]).filter(f => f in i);
+		for (const field of updated_fields) word[field] = i[field] || undefined;
 
 		emitter.emit('annotate', word);
 		return good({ entry: this.present(word, uname) });

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,6 +251,8 @@ Returns the entry in its new state after editing.
 > **Inputs:**
 >
 > - `id` string
+> - `gloss` string
+> - `type` string
 > - `pronominal_class` string?
 > - `frame` string?
 > - `distribution` string?
@@ -260,7 +262,8 @@ Returns the entry in its new state after editing.
 >
 > - `entry` entry
 
-Edits the entry with the given ID to have the given pronominal class, frame, distribution and subject, if they are given. Absent fields will remove the values.
+Edits the entry with the given ID to have the given gloss, type, pronominal_class, frame, distribution and/or subject.
+Absent fields will leave values unchanged. Setting a field to a falsy value clears it (i.e. makes it undefined).
 
 Returns the entry in its new state after editing.
 

--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -430,7 +430,10 @@ export default defineComponent({
 			this.update_entry(whom, { body, scope });
 			this.apisend({ action: 'edit', id: whom.id, body, scope }, data => {
 				// ...but let the API response have the final word:
-				this.update_entry(whom, data.entry);
+				this.update_entry(whom, {
+					body: data.entry.body,
+					scope: data.entry.scope,
+				});
 			});
 		},
 

--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -515,8 +515,8 @@ export default defineComponent({
 			if (this.username === this.result.user) {
 				this.$emit('edit', this.new_body, this.new_scope);
 			}
-			this.new_gloss = this.new_gloss?.trim();
-			this.new_type = this.new_type?.trim();
+			this.new_gloss = this.new_gloss?.trim() ?? '';
+			this.new_type = this.new_type?.trim() ?? '';
 			if (this.new_type === 'predicate' || !this.new_type) {
 				this.$emit(
 					'annotate',
@@ -532,10 +532,10 @@ export default defineComponent({
 					'annotate',
 					this.new_gloss,
 					this.new_type,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
+					null,
+					null,
+					null,
+					null,
 				);
 			}
 			this.editing = false;
@@ -543,10 +543,10 @@ export default defineComponent({
 
 		guess_other_metadata(): void {
 			if (this.is_non_verb || !this.result.pronominal_class) {
-				this.result.frame = undefined;
-				this.result.distribution = undefined;
-				this.result.subject = undefined;
-				this.result.pronominal_class = undefined;
+				this.result.frame = null;
+				this.result.distribution = null;
+				this.result.subject = null;
+				this.result.pronominal_class = null;
 				return;
 			}
 			this.result.type = this.result.type ? this.result.type : 'predicate';

--- a/modules/housekeep.ts
+++ b/modules/housekeep.ts
@@ -1,6 +1,7 @@
 // modules/housekeep.js
 // tamper with the database store
 
+import { FIXED_ANNOTATION_FIELDS } from '../core/api.js';
 import type * as commons from '../core/commons.js';
 import { tryAssessType, type Token } from '../core/commons.js';
 import { Search } from '../core/search.js';
@@ -54,6 +55,13 @@ export class HousekeepModule {
 			if (entry.subject === 'predicate') {
 				entry.subject = 'proposition';
 				didReform = true;
+			}
+
+			// All valid annotation values are truthy
+			if (!entry.gloss) entry.gloss = undefined;
+			if (!entry.type) entry.type = undefined;
+			for (const field of FIXED_ANNOTATION_FIELDS) {
+				if (!entry[field]) entry[field] = undefined;
 			}
 
 			const placeholderRegex = /___|◌(?!\p{Diacritic})/gu;

--- a/modules/update.ts
+++ b/modules/update.ts
@@ -66,7 +66,7 @@ const FORMATS: Record<string, UpdateFormat> = {
 						}
 						return value;
 					});
-					if (!any_undefined) {
+					if (!any_undefined && value !== '') {
 						filled[k] = value;
 					}
 				}


### PR DESCRIPTION
Closes #94. See #107.