### PR TITLE
show metadata for `predicatizer` entries like `predicate`

### DIFF
--- a/frontend/Result.vue
+++ b/frontend/Result.vue
@@ -670,7 +670,11 @@ export default defineComponent({
 			return this.result.frame?.endsWith('c');
 		},
 		is_non_verb(): boolean {
-			return this.result.type && this.result.type !== 'predicate';
+			return (
+				this.result.type &&
+				this.result.type !== 'predicate' &&
+				this.result.type !== 'predicatizer'
+			);
 		},
 		has_slots(): boolean {
 			return this.result.body?.includes('▯');


### PR DESCRIPTION
The `is_non_verb` computed only treated `predicate` as verb-like, so `predicatizer` entries were classified as non-verbs and had their frame/distribution/subject/pronominal-class metadata hidden even when they have slots. Include `predicatizer` alongside `predicate` so those fields show as they do for predicates.

Fixes #110.